### PR TITLE
PR feature/to-do-app-crud/oauth-client-refactoring 파라미터 바인딩 및 이와 관련된 의존성 조정

### DIFF
--- a/week4/src/main/kotlin/kotlinassignment/week4/domain/member/controller/OAuth2MemberController.kt
+++ b/week4/src/main/kotlin/kotlinassignment/week4/domain/member/controller/OAuth2MemberController.kt
@@ -5,7 +5,7 @@ import kotlinassignment.week4.domain.member.dto.LoginResponse
 import kotlinassignment.week4.domain.member.service.OAuth2LoginService
 import kotlinassignment.week4.infra.client.oauth2.OAuth2Client
 import kotlinassignment.week4.infra.client.oauth2.config.OAuth2Provider
-import kotlinassignment.week4.infra.client.oauth2.config.OAuth2ProviderPropertiesResolver
+import kotlinassignment.week4.infra.client.oauth2.config.OAuth2ProviderPropertiesMapper
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -18,7 +18,7 @@ import java.net.URI
 /* 챌린지반 강의 코드 가져와서 수정 + https://velog.io/@max9106/OAuth4 참고 */
 @RestController
 class OAuth2MemberController(
-    private val resolver: OAuth2ProviderPropertiesResolver,
+    private val mapper: OAuth2ProviderPropertiesMapper,
     private val oAuth2LoginService: OAuth2LoginService,
     private val oAuth2Client: OAuth2Client,
 ) {
@@ -31,7 +31,7 @@ class OAuth2MemberController(
     ): ResponseEntity<Unit> {
 /*        val loginPageUrl = resolver.getOAuth2Properties(oAuth2ProviderName)
             .let { oAuth2Client.generateLoginPageUrl(it) }*/
-        val loginPageUrl = resolver.getOAuth2Properties(oAuth2Provider)
+        val loginPageUrl = mapper.getOAuth2Properties(oAuth2Provider)
             .let { oAuth2Client.generateLoginPageUrl(it) }
 
         // response.sendRedirect(loginPageUrl) 왼쪽과 같은 HttpServletResponse가 아니라 ResponseEntity로도 redirect 가능 - https://shanepark.tistory.com/370
@@ -46,8 +46,8 @@ class OAuth2MemberController(
         @PathVariable oAuth2ProviderName: String,
         @RequestParam(name = "code") authorizationCode: String,
     ): ResponseEntity<LoginResponse> {
-        val properties = resolver.getOAuth2Properties(oAuth2ProviderName)
-        val oAuth2Provider = resolver.getOAuth2Provider(oAuth2ProviderName)
+        val properties = mapper.getOAuth2Properties(oAuth2ProviderName)
+        val oAuth2Provider = mapper.getOAuth2Provider(oAuth2ProviderName)
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/week4/src/main/kotlin/kotlinassignment/week4/domain/member/controller/OAuth2MemberController.kt
+++ b/week4/src/main/kotlin/kotlinassignment/week4/domain/member/controller/OAuth2MemberController.kt
@@ -41,13 +41,12 @@ class OAuth2MemberController(
     }
 
     // 2. authorization code를 받아서 사용자 인증을 처리(access token 발급 요청, 사용자 정보 요청, access token 발행 등)
-    @GetMapping("/oauth2/callback/{oAuth2ProviderName}") // redirect url
+    @GetMapping("/oauth2/callback/{oAuth2Provider}") // redirect url
     fun callback(
-        @PathVariable oAuth2ProviderName: String,
+        oAuth2Provider: OAuth2Provider,
         @RequestParam(name = "code") authorizationCode: String,
     ): ResponseEntity<LoginResponse> {
-        val properties = mapper.getOAuth2Properties(oAuth2ProviderName)
-        val oAuth2Provider = mapper.getOAuth2Provider(oAuth2ProviderName)
+        val properties = mapper.getOAuth2Properties(oAuth2Provider)
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/week4/src/main/kotlin/kotlinassignment/week4/domain/member/controller/OAuth2MemberController.kt
+++ b/week4/src/main/kotlin/kotlinassignment/week4/domain/member/controller/OAuth2MemberController.kt
@@ -10,7 +10,6 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.net.URI
@@ -29,8 +28,6 @@ class OAuth2MemberController(
         oAuth2Provider: OAuth2Provider,
         response: HttpServletResponse,
     ): ResponseEntity<Unit> {
-/*        val loginPageUrl = resolver.getOAuth2Properties(oAuth2ProviderName)
-            .let { oAuth2Client.generateLoginPageUrl(it) }*/
         val loginPageUrl = mapper.getOAuth2Properties(oAuth2Provider)
             .let { oAuth2Client.generateLoginPageUrl(it) }
 
@@ -50,6 +47,6 @@ class OAuth2MemberController(
 
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(oAuth2LoginService.login(properties, oAuth2Provider, authorizationCode))
+                .body(oAuth2LoginService.login(properties, authorizationCode))
     }
 }

--- a/week4/src/main/kotlin/kotlinassignment/week4/domain/member/controller/OAuth2MemberController.kt
+++ b/week4/src/main/kotlin/kotlinassignment/week4/domain/member/controller/OAuth2MemberController.kt
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletResponse
 import kotlinassignment.week4.domain.member.dto.LoginResponse
 import kotlinassignment.week4.domain.member.service.OAuth2LoginService
 import kotlinassignment.week4.infra.client.oauth2.OAuth2Client
+import kotlinassignment.week4.infra.client.oauth2.config.OAuth2ProviderPropertiesResolver
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -16,6 +17,7 @@ import java.net.URI
 /* 챌린지반 강의 코드 가져와서 수정 + https://velog.io/@max9106/OAuth4 참고 */
 @RestController
 class OAuth2MemberController(
+    private val resolver: OAuth2ProviderPropertiesResolver,
     private val oAuth2LoginService: OAuth2LoginService,
     private val oAuth2Client: OAuth2Client,
 ) {
@@ -26,13 +28,13 @@ class OAuth2MemberController(
         @PathVariable oAuth2ProviderName: String,
         response: HttpServletResponse,
     ): ResponseEntity<Unit> {
-        val loginPageUrl = oAuth2Client.generateLoginPageUrl(oAuth2ProviderName)
+        val loginPageUrl = resolver.getOAuth2Properties(oAuth2ProviderName)
+            .let { oAuth2Client.generateLoginPageUrl(it) }
 
-        // response.sendRedirect(loginPageUrl) 왼쪽과 같은 HttpServletResponse가 아니라 ResponseEntity로도 redirect 가능
-        // - https://shanepark.tistory.com/370
+        // response.sendRedirect(loginPageUrl) 왼쪽과 같은 HttpServletResponse가 아니라 ResponseEntity로도 redirect 가능 - https://shanepark.tistory.com/370
         val headers = HttpHeaders().apply { this.location = URI.create(loginPageUrl) }
-        // 이 303 코드가 맞을까? https://developer.mozilla.org/ko/docs/Web/HTTP/Status/303
-        return ResponseEntity(headers, HttpStatus.SEE_OTHER)
+
+        return ResponseEntity(headers, HttpStatus.SEE_OTHER) // 이 303 코드가 맞을까? https://developer.mozilla.org/ko/docs/Web/HTTP/Status/303
     }
 
     // 2. authorization code를 받아서 사용자 인증을 처리(access token 발급 요청, 사용자 정보 요청, access token 발행 등)
@@ -41,8 +43,11 @@ class OAuth2MemberController(
         @PathVariable oAuth2ProviderName: String,
         @RequestParam(name = "code") authorizationCode: String,
     ): ResponseEntity<LoginResponse> {
+        val properties = resolver.getOAuth2Properties(oAuth2ProviderName)
+        val oAuth2Provider = resolver.getOAuth2Provider(oAuth2ProviderName)
+
         return ResponseEntity
-            .status(HttpStatus.OK)
-            .body(oAuth2LoginService.login(oAuth2ProviderName, authorizationCode))
+                .status(HttpStatus.OK)
+                .body(oAuth2LoginService.login(properties, oAuth2Provider, authorizationCode))
     }
 }

--- a/week4/src/main/kotlin/kotlinassignment/week4/domain/member/controller/OAuth2MemberController.kt
+++ b/week4/src/main/kotlin/kotlinassignment/week4/domain/member/controller/OAuth2MemberController.kt
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletResponse
 import kotlinassignment.week4.domain.member.dto.LoginResponse
 import kotlinassignment.week4.domain.member.service.OAuth2LoginService
 import kotlinassignment.week4.infra.client.oauth2.OAuth2Client
+import kotlinassignment.week4.infra.client.oauth2.config.OAuth2Provider
 import kotlinassignment.week4.infra.client.oauth2.config.OAuth2ProviderPropertiesResolver
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
@@ -23,12 +24,14 @@ class OAuth2MemberController(
 ) {
 
     // 1. 로그인 페이지로 Redirect 해주는 API
-    @GetMapping("/oauth2/login/{oAuth2ProviderName}")
+    @GetMapping("/oauth2/login/{oAuth2Provider}")
     fun redirectLoginPage(
-        @PathVariable oAuth2ProviderName: String,
+        oAuth2Provider: OAuth2Provider,
         response: HttpServletResponse,
     ): ResponseEntity<Unit> {
-        val loginPageUrl = resolver.getOAuth2Properties(oAuth2ProviderName)
+/*        val loginPageUrl = resolver.getOAuth2Properties(oAuth2ProviderName)
+            .let { oAuth2Client.generateLoginPageUrl(it) }*/
+        val loginPageUrl = resolver.getOAuth2Properties(oAuth2Provider)
             .let { oAuth2Client.generateLoginPageUrl(it) }
 
         // response.sendRedirect(loginPageUrl) 왼쪽과 같은 HttpServletResponse가 아니라 ResponseEntity로도 redirect 가능 - https://shanepark.tistory.com/370

--- a/week4/src/main/kotlin/kotlinassignment/week4/domain/member/service/OAuth2LoginService.kt
+++ b/week4/src/main/kotlin/kotlinassignment/week4/domain/member/service/OAuth2LoginService.kt
@@ -2,7 +2,7 @@ package kotlinassignment.week4.domain.member.service
 
 import kotlinassignment.week4.domain.member.dto.LoginResponse
 import kotlinassignment.week4.infra.client.oauth2.OAuth2Client
-import kotlinassignment.week4.infra.client.oauth2.config.OAuth2Properties
+import kotlinassignment.week4.infra.client.oauth2.config.OAuth2Provider
 import kotlinassignment.week4.util.JwtTokenManager
 import org.springframework.stereotype.Service
 
@@ -14,10 +14,10 @@ class OAuth2LoginService(
     private val jwtTokenManager: JwtTokenManager,
 ) {
 
-    fun login(properties: OAuth2Properties, authorizationCode: String): LoginResponse {
-        return oAuth2Client.getAccessToken(properties, authorizationCode)
-            .let { oAuth2Client.retrieveUserInfo(properties, accessToken = it) }
-            .let { socialMemberService.registerIfAbsent(properties.oAuth2Provider, userInfoResponse = it) }
+    fun login(provider: OAuth2Provider, authorizationCode: String): LoginResponse {
+        return oAuth2Client.getAccessToken(provider, authorizationCode)
+            .let { oAuth2Client.retrieveUserInfo(provider, accessToken = it) }
+            .let { socialMemberService.registerIfAbsent(provider, userInfoResponse = it) }
             .let {
                 LoginResponse(
                     id = it.id!!,

--- a/week4/src/main/kotlin/kotlinassignment/week4/domain/member/service/OAuth2LoginService.kt
+++ b/week4/src/main/kotlin/kotlinassignment/week4/domain/member/service/OAuth2LoginService.kt
@@ -2,7 +2,8 @@ package kotlinassignment.week4.domain.member.service
 
 import kotlinassignment.week4.domain.member.dto.LoginResponse
 import kotlinassignment.week4.infra.client.oauth2.OAuth2Client
-import kotlinassignment.week4.infra.client.oauth2.config.OAuth2ProviderPropertiesResolver
+import kotlinassignment.week4.infra.client.oauth2.config.OAuth2Properties
+import kotlinassignment.week4.infra.client.oauth2.config.OAuth2Provider
 import kotlinassignment.week4.util.JwtTokenManager
 import org.springframework.stereotype.Service
 
@@ -10,15 +11,14 @@ import org.springframework.stereotype.Service
 @Service
 class OAuth2LoginService(
     private val oAuth2Client: OAuth2Client,
-    private val resolver: OAuth2ProviderPropertiesResolver,
     private val socialMemberService: SocialMemberService,
     private val jwtTokenManager: JwtTokenManager,
 ) {
 
-    fun login(oAuth2ProviderName: String, authorizationCode: String): LoginResponse {
-        return oAuth2Client.getAccessToken(oAuth2ProviderName, authorizationCode)
-            .let { oAuth2Client.retrieveUserInfo(oAuth2ProviderName, accessToken = it) }
-            .let { socialMemberService.registerIfAbsent(resolver.getOAuth2Provider(oAuth2ProviderName), userInfoResponse = it) }
+    fun login(properties: OAuth2Properties, oAuth2Provider: OAuth2Provider, authorizationCode: String): LoginResponse {
+        return oAuth2Client.getAccessToken(properties, authorizationCode)
+            .let { oAuth2Client.retrieveUserInfo(properties, accessToken = it) }
+            .let { socialMemberService.registerIfAbsent(oAuth2Provider, userInfoResponse = it) }
             .let {
                 LoginResponse(
                     id = it.id!!,

--- a/week4/src/main/kotlin/kotlinassignment/week4/domain/member/service/OAuth2LoginService.kt
+++ b/week4/src/main/kotlin/kotlinassignment/week4/domain/member/service/OAuth2LoginService.kt
@@ -3,7 +3,6 @@ package kotlinassignment.week4.domain.member.service
 import kotlinassignment.week4.domain.member.dto.LoginResponse
 import kotlinassignment.week4.infra.client.oauth2.OAuth2Client
 import kotlinassignment.week4.infra.client.oauth2.config.OAuth2Properties
-import kotlinassignment.week4.infra.client.oauth2.config.OAuth2Provider
 import kotlinassignment.week4.util.JwtTokenManager
 import org.springframework.stereotype.Service
 
@@ -15,10 +14,10 @@ class OAuth2LoginService(
     private val jwtTokenManager: JwtTokenManager,
 ) {
 
-    fun login(properties: OAuth2Properties, oAuth2Provider: OAuth2Provider, authorizationCode: String): LoginResponse {
+    fun login(properties: OAuth2Properties, authorizationCode: String): LoginResponse {
         return oAuth2Client.getAccessToken(properties, authorizationCode)
             .let { oAuth2Client.retrieveUserInfo(properties, accessToken = it) }
-            .let { socialMemberService.registerIfAbsent(oAuth2Provider, userInfoResponse = it) }
+            .let { socialMemberService.registerIfAbsent(properties.oAuth2Provider, userInfoResponse = it) }
             .let {
                 LoginResponse(
                     id = it.id!!,

--- a/week4/src/main/kotlin/kotlinassignment/week4/infra/client/oauth2/OAuth2Client.kt
+++ b/week4/src/main/kotlin/kotlinassignment/week4/infra/client/oauth2/OAuth2Client.kt
@@ -1,6 +1,6 @@
 package kotlinassignment.week4.infra.client.oauth2
 
-import kotlinassignment.week4.infra.client.oauth2.config.OAuth2ProviderPropertiesResolver
+import kotlinassignment.week4.infra.client.oauth2.config.OAuth2Properties
 import kotlinassignment.week4.infra.client.oauth2.dto.TokenResponse
 import kotlinassignment.week4.infra.client.oauth2.dto.UserInfoResponse
 import org.springframework.http.MediaType
@@ -13,25 +13,18 @@ import org.springframework.web.client.body
 @Component
 class OAuth2Client(
     private val restClient: RestClient,
-    private val resolver: OAuth2ProviderPropertiesResolver,
 ) {
 
-    fun generateLoginPageUrl(oAuth2ProviderName: String): String {
-        val properties = resolver.getOAuth2Properties(oAuth2ProviderName)
-
-        val loginPageUrl = StringBuilder(properties.authBaseUri)
+    fun generateLoginPageUrl(properties: OAuth2Properties): String {
+        return StringBuilder(properties.authBaseUri)
             .append("/oauth/authorize")
             .append("?client_id=").append(properties.clientId)
             .append("&redirect_uri=").append(properties.redirectUri)
             .append("&response_type=").append("code")
             .toString()
-
-        return loginPageUrl
     }
 
-    fun getAccessToken(oAuth2ProviderName: String, authorizationCode: String): String {
-        val properties = resolver.getOAuth2Properties(oAuth2ProviderName)
-
+    fun getAccessToken(properties: OAuth2Properties, authorizationCode: String): String {
         val requestData = mutableMapOf(
             "grant_type" to "authorization_code",
             "client_id" to properties.clientId,
@@ -48,9 +41,7 @@ class OAuth2Client(
             ?: throw RuntimeException("AccessToken 조회 실패")
     }
 
-    fun retrieveUserInfo(oAuth2ProviderName: String, accessToken: String): UserInfoResponse {
-        val properties = resolver.getOAuth2Properties(oAuth2ProviderName)
-
+    fun retrieveUserInfo(properties: OAuth2Properties, accessToken: String): UserInfoResponse {
         return restClient.get()
             .uri("${properties.apiBaseUri}/v2/user/me")
             .header("Authorization", "Bearer $accessToken")

--- a/week4/src/main/kotlin/kotlinassignment/week4/infra/client/oauth2/OAuth2Client.kt
+++ b/week4/src/main/kotlin/kotlinassignment/week4/infra/client/oauth2/OAuth2Client.kt
@@ -1,6 +1,5 @@
 package kotlinassignment.week4.infra.client.oauth2
 
-import kotlinassignment.week4.infra.client.oauth2.config.OAuth2Properties
 import kotlinassignment.week4.infra.client.oauth2.config.OAuth2Provider
 import kotlinassignment.week4.infra.client.oauth2.config.OAuth2ProviderPropertiesMapper
 import kotlinassignment.week4.infra.client.oauth2.dto.TokenResponse
@@ -19,7 +18,7 @@ class OAuth2Client(
 ) {
 
     fun generateLoginPageUrl(provider: OAuth2Provider): String {
-        return getPropertiesCorrespondingWith(provider)
+        return provider.getCorrespondingProperties(mapper)
             .let {
                 StringBuilder(it.authBaseUri)
                     .append("/oauth/authorize")
@@ -31,7 +30,7 @@ class OAuth2Client(
     }
 
     fun getAccessToken(provider: OAuth2Provider, authorizationCode: String): String {
-        val properties = getPropertiesCorrespondingWith(provider)
+        val properties = provider.getCorrespondingProperties(mapper)
 
         val requestData = mutableMapOf(
             "grant_type" to "authorization_code",
@@ -50,7 +49,7 @@ class OAuth2Client(
     }
 
     fun retrieveUserInfo(provider: OAuth2Provider, accessToken: String): UserInfoResponse {
-        return getPropertiesCorrespondingWith(provider)
+        return provider.getCorrespondingProperties(mapper)
             .let {
                 restClient.get()
                     .uri("${it.apiBaseUri}/v2/user/me")
@@ -59,9 +58,5 @@ class OAuth2Client(
                     .body<UserInfoResponse>()
                     ?: throw RuntimeException("UserInfo 조회 실패")
             }
-    }
-
-    private fun getPropertiesCorrespondingWith(provider: OAuth2Provider): OAuth2Properties {
-        return mapper.getOAuth2Properties(provider)
     }
 }

--- a/week4/src/main/kotlin/kotlinassignment/week4/infra/client/oauth2/config/OAuth2Config.kt
+++ b/week4/src/main/kotlin/kotlinassignment/week4/infra/client/oauth2/config/OAuth2Config.kt
@@ -2,9 +2,17 @@ package kotlinassignment.week4.infra.client.oauth2.config
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
 @EnableConfigurationProperties(OAuth2ProviderPropertiesResolver::class)
 class OAuth2Config(
-    val oAuth2ProviderPropertiesResolver: OAuth2ProviderPropertiesResolver
-)
+    private val oAuth2ProviderPropertiesResolver: OAuth2ProviderPropertiesResolver,
+    private val oAuth2HandlerMethodArgumentResolver: OAuth2HandlerMethodArgumentResolver,
+) : WebMvcConfigurer {
+
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(oAuth2HandlerMethodArgumentResolver)
+    }
+}

--- a/week4/src/main/kotlin/kotlinassignment/week4/infra/client/oauth2/config/OAuth2Config.kt
+++ b/week4/src/main/kotlin/kotlinassignment/week4/infra/client/oauth2/config/OAuth2Config.kt
@@ -6,9 +6,9 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
-@EnableConfigurationProperties(OAuth2ProviderPropertiesResolver::class)
+@EnableConfigurationProperties(OAuth2ProviderPropertiesMapper::class)
 class OAuth2Config(
-    private val oAuth2ProviderPropertiesResolver: OAuth2ProviderPropertiesResolver,
+    private val oAuth2ProviderPropertiesMapper: OAuth2ProviderPropertiesMapper,
     private val oAuth2HandlerMethodArgumentResolver: OAuth2HandlerMethodArgumentResolver,
 ) : WebMvcConfigurer {
 

--- a/week4/src/main/kotlin/kotlinassignment/week4/infra/client/oauth2/config/OAuth2HandlerMethodArgumentResolver.kt
+++ b/week4/src/main/kotlin/kotlinassignment/week4/infra/client/oauth2/config/OAuth2HandlerMethodArgumentResolver.kt
@@ -1,0 +1,45 @@
+package kotlinassignment.week4.infra.client.oauth2.config
+
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.core.MethodParameter
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+import org.springframework.web.servlet.HandlerMapping
+
+@Component
+class OAuth2HandlerMethodArgumentResolver : HandlerMethodArgumentResolver {
+
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        // return parameter.parameterType.equals(OAuth2Provider::class)
+        // OAuth2Provider::class는 Class 타입이 아니라 KClassImpl 타입이기 때문에 아래처럼 class.java로 작성해줘야 한다.
+        return parameter.parameterType == OAuth2Provider::class.java
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?
+    ): Any? {
+        val pathVariableMap = webRequest.getNativeRequest(HttpServletRequest::class.java)
+            ?.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE) as Map<*, *> // path variable 가져오기 - https://stackoverflow.com/questions/28938540/how-can-i-access-path-variables-in-my-custom-handlermethodargumentresolver
+        val pathVariableValue = pathVariableMap[parameter.parameterName]
+
+        val oAuth2Providers = OAuth2Provider.entries
+        var target: OAuth2Provider? = null
+
+        for (i in 0..<oAuth2Providers.size) {
+            if (oAuth2Providers[i].uriSegment == pathVariableValue) {
+                target = oAuth2Providers[i]
+                break
+            } else {
+                throw IllegalArgumentException("요청 URI에 해당하는 OAuth2Provider를 찾을 수 없습니다.")
+            }
+        }
+
+        return target
+    }
+}

--- a/week4/src/main/kotlin/kotlinassignment/week4/infra/client/oauth2/config/OAuth2Properties.kt
+++ b/week4/src/main/kotlin/kotlinassignment/week4/infra/client/oauth2/config/OAuth2Properties.kt
@@ -2,6 +2,7 @@ package kotlinassignment.week4.infra.client.oauth2.config
 
 /* https://velog.io/@max9106/OAuth4 참고 */
 data class OAuth2Properties(
+    val oAuth2Provider: OAuth2Provider,
     val authBaseUri: String,
     val clientId: String,
     val redirectUri: String,

--- a/week4/src/main/kotlin/kotlinassignment/week4/infra/client/oauth2/config/OAuth2Provider.kt
+++ b/week4/src/main/kotlin/kotlinassignment/week4/infra/client/oauth2/config/OAuth2Provider.kt
@@ -2,5 +2,9 @@ package kotlinassignment.week4.infra.client.oauth2.config
 
 /* 챌린지반 강의 코드 가져와서 일부 수정 */
 enum class OAuth2Provider(val uriSegment: String) {
-    KAKAO("kakao"), NAVER("naver")
+    KAKAO("kakao"), NAVER("naver");
+
+    fun getCorrespondingProperties(mapper: OAuth2ProviderPropertiesMapper): OAuth2Properties { // mapper는 서버가 뜨면서 동적으로 생성되므로 주입받아야 한다.
+        return mapper.getOAuth2Properties(this)
+    }
 }

--- a/week4/src/main/kotlin/kotlinassignment/week4/infra/client/oauth2/config/OAuth2Provider.kt
+++ b/week4/src/main/kotlin/kotlinassignment/week4/infra/client/oauth2/config/OAuth2Provider.kt
@@ -1,6 +1,6 @@
 package kotlinassignment.week4.infra.client.oauth2.config
 
 /* 챌린지반 강의 코드 가져와서 일부 수정 */
-enum class OAuth2Provider(val uriPostfix: String) {
+enum class OAuth2Provider(val uriSegment: String) {
     KAKAO("kakao"), NAVER("naver")
 }

--- a/week4/src/main/kotlin/kotlinassignment/week4/infra/client/oauth2/config/OAuth2ProviderPropertiesMapper.kt
+++ b/week4/src/main/kotlin/kotlinassignment/week4/infra/client/oauth2/config/OAuth2ProviderPropertiesMapper.kt
@@ -3,7 +3,7 @@ package kotlinassignment.week4.infra.client.oauth2.config
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties("oauth2")
-class OAuth2ProviderPropertiesResolver(
+class OAuth2ProviderPropertiesMapper(
     private val providerPropertiesMap: MutableMap<OAuth2Provider, OAuth2Properties>
 ) {
 

--- a/week4/src/main/kotlin/kotlinassignment/week4/infra/client/oauth2/config/OAuth2ProviderPropertiesMapper.kt
+++ b/week4/src/main/kotlin/kotlinassignment/week4/infra/client/oauth2/config/OAuth2ProviderPropertiesMapper.kt
@@ -7,21 +7,8 @@ class OAuth2ProviderPropertiesMapper(
     private val providerPropertiesMap: MutableMap<OAuth2Provider, OAuth2Properties>
 ) {
 
-    fun getOAuth2Properties(oAuth2ProviderName: String): OAuth2Properties {
-        return getOAuth2Provider(oAuth2ProviderName)
-            .let { this.providerPropertiesMap[it] }
-            ?: throw IllegalArgumentException("OAuth2Provider와 일치하는 OAuth2Properties를 찾을 수 없습니다.")
-    }
-
     fun getOAuth2Properties(oAuth2Provider: OAuth2Provider): OAuth2Properties {
         return this.providerPropertiesMap[oAuth2Provider]
             ?: throw IllegalArgumentException("OAuth2Provider와 일치하는 OAuth2Properties를 찾을 수 없습니다.")
-    }
-
-    fun getOAuth2Provider(oAuth2ProviderName: String): OAuth2Provider {
-        if (oAuth2ProviderName !in OAuth2Provider.entries.map { it.uriSegment }) {
-            throw IllegalArgumentException("요청 URI에 해당하는 OAuth2Provider를 찾을 수 없습니다.")
-        }
-        return OAuth2Provider.valueOf(oAuth2ProviderName.uppercase())
     }
 }

--- a/week4/src/main/kotlin/kotlinassignment/week4/infra/client/oauth2/config/OAuth2ProviderPropertiesResolver.kt
+++ b/week4/src/main/kotlin/kotlinassignment/week4/infra/client/oauth2/config/OAuth2ProviderPropertiesResolver.kt
@@ -4,12 +4,17 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties("oauth2")
 class OAuth2ProviderPropertiesResolver(
-    val providerPropertiesMap: MutableMap<OAuth2Provider, OAuth2Properties>
+    private val providerPropertiesMap: MutableMap<OAuth2Provider, OAuth2Properties>
 ) {
 
     fun getOAuth2Properties(oAuth2ProviderName: String): OAuth2Properties {
         return getOAuth2Provider(oAuth2ProviderName)
             .let { this.providerPropertiesMap[it] }
+            ?: throw IllegalArgumentException("OAuth2Provider와 일치하는 OAuth2Properties를 찾을 수 없습니다.")
+    }
+
+    fun getOAuth2Properties(oAuth2Provider: OAuth2Provider): OAuth2Properties {
+        return this.providerPropertiesMap[oAuth2Provider]
             ?: throw IllegalArgumentException("OAuth2Provider와 일치하는 OAuth2Properties를 찾을 수 없습니다.")
     }
 

--- a/week4/src/main/kotlin/kotlinassignment/week4/infra/client/oauth2/config/OAuth2ProviderPropertiesResolver.kt
+++ b/week4/src/main/kotlin/kotlinassignment/week4/infra/client/oauth2/config/OAuth2ProviderPropertiesResolver.kt
@@ -14,7 +14,7 @@ class OAuth2ProviderPropertiesResolver(
     }
 
     fun getOAuth2Provider(oAuth2ProviderName: String): OAuth2Provider {
-        if (oAuth2ProviderName !in OAuth2Provider.entries.map { it.uriPostfix }) {
+        if (oAuth2ProviderName !in OAuth2Provider.entries.map { it.uriSegment }) {
             throw IllegalArgumentException("요청 URI에 해당하는 OAuth2Provider를 찾을 수 없습니다.")
         }
         return OAuth2Provider.valueOf(oAuth2ProviderName.uppercase())

--- a/week4/src/main/resources/application-oauth.yml
+++ b/week4/src/main/resources/application-oauth.yml
@@ -2,11 +2,13 @@
 oauth2:
   provider-properties-map:
     KAKAO:
+      o-auth2-provider: KAKAO
       auth-base-uri: TODO
       client-id: TODO
       redirect-uri: http://localhost:8080/oauth2/callback/kakao
       api-base-uri: TODO
     NAVER:
+      o-auth2-provider: NAVER
       auth-base-uri: TODO
       client-id: TODO
       redirect-uri: http://localhost:8080/oauth2/callback/naver


### PR DESCRIPTION
- HandlerMethodArgumentResolver 사용하여 controller에서 request의 파라미터를 받아올 때 oAuth2ProviderName으로 String을 받아오지 않고, 바로 OAuth2Provider enum으로 받아옴
- 혼란스러우므로 기존 OAuth2ProviderPropertiesResolver의 클래스 이름을 OAuth2ProviderPropertiesMapper로 변경
- OAuth controller와 service는 provider만 알게 함
  - mapper, properties에 대해 모두 알고 있는 것은 client
  - parameter binding + 의존성과 책임에 대해 생각하며 호출을 조정함