### PR TITLE
PR feature/week10/20240130 - 예외 공통화 처리, service 인터페이스 분리

### DIFF
--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/service/CommentService.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/service/CommentService.kt
@@ -3,63 +3,32 @@ package kotlinassignment.week10.domain.comment.service
 import kotlinassignment.week10.domain.comment.dto.CommentCreateRequest
 import kotlinassignment.week10.domain.comment.dto.CommentResponse
 import kotlinassignment.week10.domain.comment.dto.CommentUpdateRequest
-import kotlinassignment.week10.domain.comment.model.Comment
-import kotlinassignment.week10.domain.comment.model.toResponse
-import kotlinassignment.week10.domain.comment.model.updateFrom
-import kotlinassignment.week10.domain.comment.repository.CommentRepository
-import kotlinassignment.week10.domain.exception.IncorrectRelatedEntityIdException
-import kotlinassignment.week10.domain.exception.ModelNotFoundException
-import kotlinassignment.week10.domain.exception.UnauthorizedAccessException
-import kotlinassignment.week10.domain.member.repository.MemberRepository
-import kotlinassignment.week10.domain.toDoCard.repository.ToDoCardRepository
 import kotlinassignment.week10.infra.security.MemberPrincipal
-import org.springframework.data.repository.findByIdOrNull
-import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 
-@Service
-class CommentService(
-    private val toDoCardIdRepository: ToDoCardRepository,
-    private val commentRepository: CommentRepository,
-    private val memberRepository: MemberRepository,
-) {
+interface CommentService {
 
-    @Transactional
-    fun createComment(toDoCardId: Long, request: CommentCreateRequest, memberPrincipal: MemberPrincipal): CommentResponse {
-        val targetToDoCard = toDoCardIdRepository.findByIdOrNull(toDoCardId) ?: throw ModelNotFoundException("ToDoCard", toDoCardId)
-        val member = memberRepository.findByIdOrNull(memberPrincipal.id) ?:throw ModelNotFoundException("Member", memberPrincipal.id)
+    /**
+     * @param toDoCardId (type: Long) Comment와 연관된 ToDoCard의 id
+     * @param request (type: CommentCreateRequest) Comment 생성을 위한 DTO
+     * @param memberPrincipal (type: MemberPrincipal) 인증된 member의 정보를 담고 있는 객체
+     * @return (type: CommentResponse) Comment 생성 후 생성된 Comment를 보여주기 위해 반환하는 데이터
+     */
+    fun createComment(toDoCardId: Long, request: CommentCreateRequest, memberPrincipal: MemberPrincipal): CommentResponse
 
-        return Comment(
-            content = request.content,
-            member = member,
-            createdDateTime = request.createdDateTime,
-            toDoCard = targetToDoCard,
-        ).let { commentRepository.save(it).toResponse() }
-    }
+    /**
+     * @param toDoCardId (type: Long) Comment와 연관된 ToDoCard의 id
+     * @param commentId (type: Long) 수정할 Comment의 id
+     * @param request (type: CommentUpdateRequest) Comment 수정을 위한 DTO
+     * @param memberPrincipal (type: MemberPrincipal) 인증된 member의 정보를 담고 있는 객체
+     * @return (type: CommentResponse) Comment 수정 후 수정된 Comment를 보여주기 위해 반환하는 데이터
+     */
+    fun updateComment(toDoCardId: Long, commentId: Long, request: CommentUpdateRequest, memberPrincipal: MemberPrincipal): CommentResponse
 
-    @Transactional
-    fun updateComment(
-        toDoCardId: Long,
-        commentId: Long,
-        request: CommentUpdateRequest,
-        memberPrincipal: MemberPrincipal
-    ): CommentResponse {
-        val targetComment = commentRepository.findByIdOrNull(commentId) ?: throw ModelNotFoundException("Comment", commentId)
-
-        return targetComment
-            .also { if (it.toDoCard.id != toDoCardId) throw IncorrectRelatedEntityIdException("Comment", commentId, "ToDoCard", toDoCardId) } // Comment의 toDoCard 참조 FetchType.Lazy 지정하지 않을 경우 불필요하게 ToDoCard select 쿼리가 한 번 더 나감
-            .also { if (it.member.id != memberPrincipal.id) throw UnauthorizedAccessException() }
-            .also { it.updateFrom(request) }
-            .let { commentRepository.save(it).toResponse() }
-    }
-
-    @Transactional
-    fun deleteComment(toDoCardId: Long, commentId: Long, memberPrincipal: MemberPrincipal): Unit {
-        val targetComment = commentRepository.findByIdOrNull(commentId) ?: throw ModelNotFoundException("Comment", commentId)
-
-        targetComment
-            .also { if (it.toDoCard.id != toDoCardId) throw IncorrectRelatedEntityIdException("Comment", commentId, "ToDoCard", toDoCardId) }
-            .also { if (it.member.id != memberPrincipal.id) throw UnauthorizedAccessException() }
-            .let { commentRepository.delete(it) }
-    }
+    /**
+     * @param toDoCardId (type: Long) Comment와 연관된 ToDoCard의 id
+     * @param commentId (type: Long) 삭제할 Comment의 id
+     * @param memberPrincipal (type: MemberPrincipal) 인증된 member의 정보를 담고 있는 객체
+     * @return 없음
+     */
+    fun deleteComment(toDoCardId: Long, commentId: Long, memberPrincipal: MemberPrincipal): Unit
 }

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/service/CommentService.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/service/CommentService.kt
@@ -62,14 +62,4 @@ class CommentService(
             .also { if (it.member.id != memberPrincipal.id) throw UnauthorizedAccessException() }
             .let { commentRepository.delete(it) }
     }
-
-    /*
-    // comment entity 정책 변경으로 필요 없어진 메서드
-    private fun getCommentIfUserNameAndPasswordMatches(commentId: Long, userNameRequested: String, passwordRequested: String): Comment {
-        // ?? propagation = PROPAGATION.REQUIRED로 될까? 이렇게 따로 추출한 메서드는 transaction 처리 어떻게 되는지 알아보기
-        // 암호화 될 password는 서버까지 끌고 오지 않고, DB 서버 내에서 비교 후 일치하면 처리되도록 할 것
-        return commentRepository.findByIdAndUserNameAndPassword(commentId, userNameRequested, passwordRequested)
-            ?: throw PasswordMismatchException("Comment", commentId)
-    }
-     */
 }

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/service/CommentServiceImpl.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/service/CommentServiceImpl.kt
@@ -1,0 +1,65 @@
+package kotlinassignment.week10.domain.comment.service
+
+import kotlinassignment.week10.domain.comment.dto.CommentCreateRequest
+import kotlinassignment.week10.domain.comment.dto.CommentResponse
+import kotlinassignment.week10.domain.comment.dto.CommentUpdateRequest
+import kotlinassignment.week10.domain.comment.model.Comment
+import kotlinassignment.week10.domain.comment.model.toResponse
+import kotlinassignment.week10.domain.comment.model.updateFrom
+import kotlinassignment.week10.domain.comment.repository.CommentRepository
+import kotlinassignment.week10.domain.exception.IncorrectRelatedEntityIdException
+import kotlinassignment.week10.domain.exception.ModelNotFoundException
+import kotlinassignment.week10.domain.exception.UnauthorizedAccessException
+import kotlinassignment.week10.domain.member.repository.MemberRepository
+import kotlinassignment.week10.domain.toDoCard.repository.ToDoCardRepository
+import kotlinassignment.week10.infra.security.MemberPrincipal
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CommentServiceImpl(
+    private val toDoCardIdRepository: ToDoCardRepository,
+    private val commentRepository: CommentRepository,
+    private val memberRepository: MemberRepository,
+) : CommentService {
+
+    @Transactional
+    override fun createComment(toDoCardId: Long, request: CommentCreateRequest, memberPrincipal: MemberPrincipal): CommentResponse {
+        val targetToDoCard = toDoCardIdRepository.findByIdOrNull(toDoCardId) ?: throw ModelNotFoundException("ToDoCard", toDoCardId)
+        val member = memberRepository.findByIdOrNull(memberPrincipal.id) ?:throw ModelNotFoundException("Member", memberPrincipal.id)
+
+        return Comment(
+            content = request.content,
+            member = member,
+            createdDateTime = request.createdDateTime,
+            toDoCard = targetToDoCard,
+        ).let { commentRepository.save(it).toResponse() }
+    }
+
+    @Transactional
+    override fun updateComment(
+        toDoCardId: Long,
+        commentId: Long,
+        request: CommentUpdateRequest,
+        memberPrincipal: MemberPrincipal
+    ): CommentResponse {
+        val targetComment = commentRepository.findByIdOrNull(commentId) ?: throw ModelNotFoundException("Comment", commentId)
+
+        return targetComment
+            .also { if (it.toDoCard.id != toDoCardId) throw IncorrectRelatedEntityIdException("Comment", commentId, "ToDoCard", toDoCardId) } // Comment의 toDoCard 참조 FetchType.Lazy 지정하지 않을 경우 불필요하게 ToDoCard select 쿼리가 한 번 더 나감
+            .also { if (it.member.id != memberPrincipal.id) throw UnauthorizedAccessException() }
+            .also { it.updateFrom(request) }
+            .let { commentRepository.save(it).toResponse() }
+    }
+
+    @Transactional
+    override fun deleteComment(toDoCardId: Long, commentId: Long, memberPrincipal: MemberPrincipal): Unit {
+        val targetComment = commentRepository.findByIdOrNull(commentId) ?: throw ModelNotFoundException("Comment", commentId)
+
+        targetComment
+            .also { if (it.toDoCard.id != toDoCardId) throw IncorrectRelatedEntityIdException("Comment", commentId, "ToDoCard", toDoCardId) }
+            .also { if (it.member.id != memberPrincipal.id) throw UnauthorizedAccessException() }
+            .let { commentRepository.delete(it) }
+    }
+}

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/exception/DuplicatedEmailException.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/exception/DuplicatedEmailException.kt
@@ -1,0 +1,5 @@
+package kotlinassignment.week10.domain.exception
+
+data class DuplicatedEmailException(
+    override val message: String = "중복된 email이 존재합니다."
+) : RuntimeException()

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/exception/GlobalExceptionHandler.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/exception/GlobalExceptionHandler.kt
@@ -14,17 +14,10 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 @RestControllerAdvice
 class GlobalExceptionHandler {
 
-    @ExceptionHandler(ModelNotFoundException::class)
-    fun handleModelNotFoundException(e: ModelNotFoundException): ResponseEntity<ErrorResponse> {
-        return ResponseEntity
-            .status(HttpStatus.NOT_FOUND)
-            .body(ErrorResponse(message = e.message))
-    }
-
     @ExceptionHandler(HttpMessageNotReadableException::class)
     fun handleHttpMessageNotReadableException(e: HttpMessageNotReadableException): ResponseEntity<ErrorResponse> {
         return ResponseEntity
-            .status(HttpStatus.NOT_FOUND)
+            .status(HttpStatus.BAD_REQUEST)
             .body(ErrorResponse(message = "요청의 body 중 형식이 적절하지 않은 데이터가 입력되었습니다."))
         // POST /todocards 요청이 들어갈 때
         // body의 createdDateTime에 LocalDateTime 형식이 아닌 데이터(ex.단순 String) 입력 시도 때문에 추가한 exception handler
@@ -41,37 +34,44 @@ class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException::class)
-    fun handleBindException(e: MethodArgumentTypeMismatchException): ResponseEntity<ErrorResponse> {
+    fun handleMethodArgumentTypeMismatchException(e: MethodArgumentTypeMismatchException): ResponseEntity<ErrorResponse> {
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(ErrorResponse(message = "요청의 path variable 중 형식이 적절하지 않은 데이터가 입력되었습니다."))
     }
 
     @ExceptionHandler(ConstraintViolationException::class)
-    fun handleBindException(e: ConstraintViolationException): ResponseEntity<ErrorResponse> {
+    fun handleConstraintViolationException(e: ConstraintViolationException): ResponseEntity<ErrorResponse> {
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(ErrorResponse(message = e.message))
     }
 
-    @ExceptionHandler(PasswordMismatchException::class)
-    fun handlePasswordMismatchException(e: PasswordMismatchException): ResponseEntity<ErrorResponse> {
-        return ResponseEntity
-            .status(HttpStatus.FORBIDDEN)
-            .body(ErrorResponse(message = e.message))
-    }
-
     @ExceptionHandler(IncorrectRelatedEntityIdException::class)
-    fun handlePasswordMismatchException(e: IncorrectRelatedEntityIdException): ResponseEntity<ErrorResponse> {
+    fun handleIncorrectRelatedEntityIdException(e: IncorrectRelatedEntityIdException): ResponseEntity<ErrorResponse> {
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(ErrorResponse(message = e.message))
     }
 
     @ExceptionHandler(StringLengthOutOfRangeException::class)
-    fun handlePasswordMismatchException(e: StringLengthOutOfRangeException): ResponseEntity<ErrorResponse> {
+    fun handleStringLengthOutOfRangeException(e: StringLengthOutOfRangeException): ResponseEntity<ErrorResponse> {
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse(message = e.message))
+    }
+
+    @ExceptionHandler(ModelNotFoundException::class)
+    fun handleModelNotFoundException(e: ModelNotFoundException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
+            .body(ErrorResponse(message = e.message))
+    }
+
+    @ExceptionHandler(PasswordMismatchException::class)
+    fun handlePasswordMismatchException(e: PasswordMismatchException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
             .body(ErrorResponse(message = e.message))
     }
 

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/exception/GlobalExceptionHandler.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/exception/GlobalExceptionHandler.kt
@@ -61,6 +61,13 @@ class GlobalExceptionHandler {
             .body(ErrorResponse(message = e.message))
     }
 
+    @ExceptionHandler(DuplicatedEmailException::class)
+    fun handleDuplicatedEmailException(e: DuplicatedEmailException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse(message = e.message))
+    }
+
     @ExceptionHandler(ModelNotFoundException::class)
     fun handleModelNotFoundException(e: ModelNotFoundException): ResponseEntity<ErrorResponse> {
         return ResponseEntity

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/member/service/MemberService.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/member/service/MemberService.kt
@@ -1,5 +1,6 @@
 package kotlinassignment.week10.domain.member.service
 
+import kotlinassignment.week10.domain.exception.DuplicatedEmailException
 import kotlinassignment.week10.domain.member.dto.MemberLoginRequest
 import kotlinassignment.week10.domain.member.dto.MemberLoginResponse
 import kotlinassignment.week10.domain.member.dto.MemberSignUpRequest
@@ -31,7 +32,7 @@ class MemberService(
     @Transactional
     fun signUp(request: MemberSignUpRequest): Unit {
         if (memberRepository.existsByEmail(request.email)) {
-            throw IllegalStateException("Email is already in use") // TODO 예외 공통화 처리
+            throw DuplicatedEmailException()
         }
 
         memberRepository.save(

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/member/service/MemberService.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/member/service/MemberService.kt
@@ -1,46 +1,20 @@
 package kotlinassignment.week10.domain.member.service
 
-import kotlinassignment.week10.domain.exception.DuplicatedEmailException
 import kotlinassignment.week10.domain.member.dto.MemberLoginRequest
 import kotlinassignment.week10.domain.member.dto.MemberLoginResponse
 import kotlinassignment.week10.domain.member.dto.MemberSignUpRequest
-import kotlinassignment.week10.domain.member.exception.InvalidCredentialException
-import kotlinassignment.week10.domain.member.model.Member
-import kotlinassignment.week10.domain.member.repository.MemberRepository
-import kotlinassignment.week10.infra.jwt.JwtUtil
-import org.springframework.security.crypto.password.PasswordEncoder
-import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 
-@Service
-class MemberService(
-    private val memberRepository: MemberRepository,
-    private val passwordEncoder: PasswordEncoder,
-    private val jwtUtil: JwtUtil,
-) {
+interface MemberService {
 
-    fun login(request: MemberLoginRequest): MemberLoginResponse {
-        val user = memberRepository.findByEmail(request.email) ?: throw InvalidCredentialException()
+    /**
+     * @param (type: MemberLoginRequest) 회원 로그인을 위한 DTO
+     * @return (type: MemberLoginResponse) 로그인 후 반환하는 데이터
+     */
+    fun login(request: MemberLoginRequest): MemberLoginResponse
 
-        if (!passwordEncoder.matches(request.password, user.password)) {
-            throw InvalidCredentialException()
-        }
-
-        return MemberLoginResponse(accessToken = jwtUtil.generateAccessToken(user.id.toString(), user.email))
-    }
-
-    @Transactional
-    fun signUp(request: MemberSignUpRequest): Unit {
-        if (memberRepository.existsByEmail(request.email)) {
-            throw DuplicatedEmailException()
-        }
-
-        memberRepository.save(
-            Member(
-                email = request.email,
-                password = passwordEncoder.encode(request.password),
-                nickname = request.nickname,
-            )
-        )
-    }
+    /**
+     * @param (type: MemberSignUpRequest) 회원 가입을 위한 DTO
+     * @return 없음
+     */
+    fun signUp(request: MemberSignUpRequest): Unit
 }

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/member/service/MemberService.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/member/service/MemberService.kt
@@ -31,7 +31,7 @@ class MemberService(
     @Transactional
     fun signUp(request: MemberSignUpRequest): Unit {
         if (memberRepository.existsByEmail(request.email)) {
-            throw IllegalStateException("Email is already in use")
+            throw IllegalStateException("Email is already in use") // TODO 예외 공통화 처리
         }
 
         memberRepository.save(

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/member/service/MemberServiceImpl.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/member/service/MemberServiceImpl.kt
@@ -1,0 +1,46 @@
+package kotlinassignment.week10.domain.member.service
+
+import kotlinassignment.week10.domain.exception.DuplicatedEmailException
+import kotlinassignment.week10.domain.member.dto.MemberLoginRequest
+import kotlinassignment.week10.domain.member.dto.MemberLoginResponse
+import kotlinassignment.week10.domain.member.dto.MemberSignUpRequest
+import kotlinassignment.week10.domain.member.exception.InvalidCredentialException
+import kotlinassignment.week10.domain.member.model.Member
+import kotlinassignment.week10.domain.member.repository.MemberRepository
+import kotlinassignment.week10.infra.jwt.JwtUtil
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class MemberServiceImpl(
+    private val memberRepository: MemberRepository,
+    private val passwordEncoder: PasswordEncoder,
+    private val jwtUtil: JwtUtil,
+) : MemberService {
+
+    override fun login(request: MemberLoginRequest): MemberLoginResponse {
+        val user = memberRepository.findByEmail(request.email) ?: throw InvalidCredentialException()
+
+        if (!passwordEncoder.matches(request.password, user.password)) {
+            throw InvalidCredentialException()
+        }
+
+        return MemberLoginResponse(accessToken = jwtUtil.generateAccessToken(user.id.toString(), user.email))
+    }
+
+    @Transactional
+    override fun signUp(request: MemberSignUpRequest): Unit {
+        if (memberRepository.existsByEmail(request.email)) {
+            throw DuplicatedEmailException()
+        }
+
+        memberRepository.save(
+            Member(
+                email = request.email,
+                password = passwordEncoder.encode(request.password),
+                nickname = request.nickname,
+            )
+        )
+    }
+}

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardService.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardService.kt
@@ -31,10 +31,10 @@ class ToDoCardService(
         val toDoCard = toDoCardRepository.findByIdOrNull(toDoCardId) ?: throw ModelNotFoundException("ToDoCard", toDoCardId!!)
 
         /*
-         ?? ToDoCard가 참조하고 있는 comments를 사용하지 않고, comment repository 쪽에서 따로 Page 처리된 Comment들을 가져옴
-         ToDoCard에서 직접 comments를 꺼내올 때도 paging 처리되게 하려면 어떻게 해야하는지 알아보기
+         TODO ToDoCard가 참조하고 있는 comments를 사용하지 않고, comment repository 쪽에서 따로 Page 처리된 Comment들을 가져옴
+          ToDoCard에서 직접 comments를 꺼내올 때도 paging 처리되게 하려면 어떻게 해야하는지 알아보기
          */
-        val pageRequest = PageRequest.of(0, 100) // ?? 이 부분은 임시로 값을 넣어놨음, 추후 제대로 처리할 것
+        val pageRequest = PageRequest.of(0, 100) // TODO 이 부분은 임시로 값을 넣어놨음, 추후 제대로 처리할 것
         val commentPage =
             commentRepository.findByToDoCardOrderByCreatedDateTimeDesc(toDoCard, pageRequest)
 
@@ -60,10 +60,9 @@ class ToDoCardService(
     @Transactional
     fun updateToDoCard(toDoCardId: Long?, request: ToDoCardUpdateRequest, memberPrincipal: MemberPrincipal): ToDoCardResponse {
         val toDoCard = toDoCardRepository.findByIdOrNull(toDoCardId)
-            ?.also { if (it.member.id != memberPrincipal.id) throw UnauthorizedAccessException() } // TODO exception handler 처리 필요
+            ?.also { if (it.member.id != memberPrincipal.id) throw UnauthorizedAccessException() }
             ?: throw ModelNotFoundException("ToDoCard", toDoCardId!!)
 
-        // (해결?) request에 속성 추가, 정책상 변경 가능한 속성 변경 등 발생했을 때, 여기에서도 알 수 있도록 컴파일 에러를 내는 식으로 작성하려면 어떻게 해야 하는지? -> 이런 이유 때문에 굳이 구조 분해 선언 사용했던 듯하다.
         val (title: String?, description: String?) = request
         toDoCard.title = title
         toDoCard.description = description

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardService.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardService.kt
@@ -1,92 +1,50 @@
 package kotlinassignment.week10.domain.toDoCard.service
 
-import kotlinassignment.week10.domain.comment.model.toResponse
-import kotlinassignment.week10.domain.comment.repository.CommentRepository
-import kotlinassignment.week10.domain.exception.ModelNotFoundException
-import kotlinassignment.week10.domain.exception.UnauthorizedAccessException
-import kotlinassignment.week10.domain.member.repository.MemberRepository
 import kotlinassignment.week10.domain.toDoCard.dto.*
-import kotlinassignment.week10.domain.toDoCard.model.*
-import kotlinassignment.week10.domain.toDoCard.repository.ToDoCardRepository
 import kotlinassignment.week10.infra.security.MemberPrincipal
-import org.springframework.data.domain.PageRequest
-import org.springframework.data.repository.findByIdOrNull
-import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 
-@Service
-class ToDoCardService(
-    private val toDoCardRepository: ToDoCardRepository,
-    private val commentRepository: CommentRepository,
-    private val memberRepository: MemberRepository,
-) {
+interface ToDoCardService {
 
-    fun getAllToDoCards(userName: String?, sortOrder: String): List<ToDoCardResponse> {
-        return toDoCardRepository
-            .findAllFilterByUserNameAndOrderBySortOrder(userName, sortOrder)
-            .map(ToDoCard::toResponse)
-    }
+    /**
+     * @param userName (type: String?) ToDoCard 조회 시 userName으로 필터링할 경우 필요
+     * @param sortOrder (type: String) ToDoCard 조회 시 정렬할 방향
+     * @return (type: List<ToDoCardResponse>) 조회한 ToDoCard List를 반환
+     */
+    fun getAllToDoCards(userName: String?, sortOrder: String): List<ToDoCardResponse>
 
-    fun getToDoCardById(toDoCardId: Long?): ToDoCardResponseWithComments {
-        val toDoCard = toDoCardRepository.findByIdOrNull(toDoCardId) ?: throw ModelNotFoundException("ToDoCard", toDoCardId!!)
+    /**
+     * @param toDoCardId (type: Long) 조회할 ToDoCard의 id
+     * @return (type: ToDoCardResponseWithComments) parameter로 받은 ToDoCard id와 일치하는 id를 가진 ToDoCard 조회 결과 반환
+     */
+    fun getToDoCardById(toDoCardId: Long): ToDoCardResponseWithComments
 
-        /*
-         TODO ToDoCard가 참조하고 있는 comments를 사용하지 않고, comment repository 쪽에서 따로 Page 처리된 Comment들을 가져옴
-          ToDoCard에서 직접 comments를 꺼내올 때도 paging 처리되게 하려면 어떻게 해야하는지 알아보기
-         */
-        val pageRequest = PageRequest.of(0, 100) // TODO 이 부분은 임시로 값을 넣어놨음, 추후 제대로 처리할 것
-        val commentPage =
-            commentRepository.findByToDoCardOrderByCreatedDateTimeDesc(toDoCard, pageRequest)
+    /**
+     * @param request (type: ToDoCardCreateRequest) ToDoCard 생성을 위한 DTO
+     * @param memberPrincipal (type: MemberPrincipal) 인증된 member의 정보를 담고 있는 객체
+     * @return (type: ToDoCardResponse) ToDoCard 생성 후 생성된 ToDoCard를 보여주기 위해 반환하는 데이터
+     */
+    fun createToDoCard(request: ToDoCardCreateRequest, memberPrincipal: MemberPrincipal): ToDoCardResponse
 
-        return toDoCard.toResponseWithComments(commentPage.map { it.toResponse() }.toList())
-    }
+    /**
+     * @param toDoCardId (type: Long) 수정할 ToDoCard의 id
+     * @param request (type: ToDoCardUpdateRequest) ToDoCard 수정을 위한 DTO
+     * @param memberPrincipal (type: MemberPrincipal) 인증된 member의 정보를 담고 있는 객체
+     * @return (type: ToDoCardResponse) ToDoCard 수정 후 수정된 ToDoCard를 보여주기 위해 반환하는 데이터
+     */
+    fun updateToDoCard(toDoCardId: Long, request: ToDoCardUpdateRequest, memberPrincipal: MemberPrincipal): ToDoCardResponse
 
-    @Transactional
-    fun createToDoCard(
-        request: ToDoCardCreateRequest,
-        memberPrincipal: MemberPrincipal,
-    ): ToDoCardResponse {
+    /**
+     * @param toDoCardId (type: Long) 삭제할 ToDoCard의 id
+     * @param memberPrincipal (type: MemberPrincipal) 인증된 member의 정보를 담고 있는 객체
+     * @return (type: Unit) 없음
+     */
+    fun deleteToDoCard(toDoCardId: Long, memberPrincipal: MemberPrincipal): Unit
 
-        val member = memberRepository.findByIdOrNull(memberPrincipal.id) ?: throw ModelNotFoundException("Member", memberPrincipal.id)
-
-        return ToDoCard(
-            title = request.title,
-            description = request.description,
-            member = member,
-            createdDateTime = request.createdDateTime,
-        ).let { toDoCardRepository.save(it).toResponse() }
-    }
-
-    @Transactional
-    fun updateToDoCard(toDoCardId: Long?, request: ToDoCardUpdateRequest, memberPrincipal: MemberPrincipal): ToDoCardResponse {
-        val toDoCard = toDoCardRepository.findByIdOrNull(toDoCardId)
-            ?.also { if (it.member.id != memberPrincipal.id) throw UnauthorizedAccessException() }
-            ?: throw ModelNotFoundException("ToDoCard", toDoCardId!!)
-
-        val (title: String?, description: String?) = request
-        toDoCard.title = title
-        toDoCard.description = description
-
-        return toDoCardRepository.save(toDoCard).toResponse()
-    }
-
-    @Transactional
-    fun deleteToDoCard(toDoCardId: Long?, memberPrincipal: MemberPrincipal): Unit {
-        // 이 부분이 있어도 select query는 한 번만 나간다. 없는 id로 delete 시도하는 경우 확실한 에러 메시지를 주기 위함
-        val toDoCard = toDoCardRepository.findByIdOrNull(toDoCardId)
-            ?.also { if (it.member.id != memberPrincipal.id) throw UnauthorizedAccessException() }
-            ?: throw ModelNotFoundException("ToDoCard", toDoCardId!!)
-
-        return toDoCardRepository.delete(toDoCard)
-    }
-
-    @Transactional
-    fun completeToDoCard(toDoCardId: Long?, request: ToDoCardIsCompletePatchRequest, memberPrincipal: MemberPrincipal): ToDoCardResponse {
-        val toDoCard = toDoCardRepository.findByIdOrNull(toDoCardId)
-            ?.also { if (it.member.id != memberPrincipal.id) throw UnauthorizedAccessException() }
-            ?: throw ModelNotFoundException("ToDoCard", toDoCardId!!)
-        toDoCard.isComplete = request.isComplete
-
-        return toDoCard.toResponse()
-    }
+    /**
+     * @param toDoCardId (type: Long) 완료 처리할 ToDoCard의 id
+     * @param request (type: ToDoCardIsCompletePatchRequest) ToDoCard 완료 여부 수정을 위한 DTO
+     * @param memberPrincipal (type: MemberPrincipal) 인증된 member의 정보를 담고 있는 객체
+     * @return (type: ToDoCardResponse) ToDoCard 완료 여부 수정 후 수정된 ToDoCard를 보여주기 위해 반환하는 데이터
+     */
+    fun completeToDoCard(toDoCardId: Long, request: ToDoCardIsCompletePatchRequest, memberPrincipal: MemberPrincipal): ToDoCardResponse
 }

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardServiceImpl.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardServiceImpl.kt
@@ -1,0 +1,92 @@
+package kotlinassignment.week10.domain.toDoCard.service
+
+import kotlinassignment.week10.domain.comment.model.toResponse
+import kotlinassignment.week10.domain.comment.repository.CommentRepository
+import kotlinassignment.week10.domain.exception.ModelNotFoundException
+import kotlinassignment.week10.domain.exception.UnauthorizedAccessException
+import kotlinassignment.week10.domain.member.repository.MemberRepository
+import kotlinassignment.week10.domain.toDoCard.dto.*
+import kotlinassignment.week10.domain.toDoCard.model.*
+import kotlinassignment.week10.domain.toDoCard.repository.ToDoCardRepository
+import kotlinassignment.week10.infra.security.MemberPrincipal
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class ToDoCardServiceImpl(
+    private val toDoCardRepository: ToDoCardRepository,
+    private val commentRepository: CommentRepository,
+    private val memberRepository: MemberRepository,
+): ToDoCardService {
+
+    override fun getAllToDoCards(userName: String?, sortOrder: String): List<ToDoCardResponse> {
+        return toDoCardRepository
+            .findAllFilterByUserNameAndOrderBySortOrder(userName, sortOrder)
+            .map(ToDoCard::toResponse)
+    }
+
+    override fun getToDoCardById(toDoCardId: Long): ToDoCardResponseWithComments {
+        val toDoCard = toDoCardRepository.findByIdOrNull(toDoCardId) ?: throw ModelNotFoundException("ToDoCard", toDoCardId)
+
+        /*
+         TODO ToDoCard가 참조하고 있는 comments를 사용하지 않고, comment repository 쪽에서 따로 Page 처리된 Comment들을 가져옴
+          ToDoCard에서 직접 comments를 꺼내올 때도 paging 처리되게 하려면 어떻게 해야하는지 알아보기
+         */
+        val pageRequest = PageRequest.of(0, 100) // TODO 이 부분은 임시로 값을 넣어놨음, 추후 제대로 처리할 것
+        val commentPage =
+            commentRepository.findByToDoCardOrderByCreatedDateTimeDesc(toDoCard, pageRequest)
+
+        return toDoCard.toResponseWithComments(commentPage.map { it.toResponse() }.toList())
+    }
+
+    @Transactional
+    override fun createToDoCard(
+        request: ToDoCardCreateRequest,
+        memberPrincipal: MemberPrincipal,
+    ): ToDoCardResponse {
+
+        val member = memberRepository.findByIdOrNull(memberPrincipal.id) ?: throw ModelNotFoundException("Member", memberPrincipal.id)
+
+        return ToDoCard(
+            title = request.title,
+            description = request.description,
+            member = member,
+            createdDateTime = request.createdDateTime,
+        ).let { toDoCardRepository.save(it).toResponse() }
+    }
+
+    @Transactional
+    override fun updateToDoCard(toDoCardId: Long, request: ToDoCardUpdateRequest, memberPrincipal: MemberPrincipal): ToDoCardResponse {
+        val toDoCard = toDoCardRepository.findByIdOrNull(toDoCardId)
+            ?.also { if (it.member.id != memberPrincipal.id) throw UnauthorizedAccessException() }
+            ?: throw ModelNotFoundException("ToDoCard", toDoCardId)
+
+        val (title: String?, description: String?) = request
+        toDoCard.title = title
+        toDoCard.description = description
+
+        return toDoCardRepository.save(toDoCard).toResponse()
+    }
+
+    @Transactional
+    override fun deleteToDoCard(toDoCardId: Long, memberPrincipal: MemberPrincipal): Unit {
+        // 이 부분이 있어도 select query는 한 번만 나간다. 없는 id로 delete 시도하는 경우 확실한 에러 메시지를 주기 위함
+        val toDoCard = toDoCardRepository.findByIdOrNull(toDoCardId)
+            ?.also { if (it.member.id != memberPrincipal.id) throw UnauthorizedAccessException() }
+            ?: throw ModelNotFoundException("ToDoCard", toDoCardId)
+
+        return toDoCardRepository.delete(toDoCard)
+    }
+
+    @Transactional
+    override fun completeToDoCard(toDoCardId: Long, request: ToDoCardIsCompletePatchRequest, memberPrincipal: MemberPrincipal): ToDoCardResponse {
+        val toDoCard = toDoCardRepository.findByIdOrNull(toDoCardId)
+            ?.also { if (it.member.id != memberPrincipal.id) throw UnauthorizedAccessException() }
+            ?: throw ModelNotFoundException("ToDoCard", toDoCardId)
+        toDoCard.isComplete = request.isComplete
+
+        return toDoCard.toResponse()
+    }
+}

--- a/week10/src/test/kotlin/kotlinassignment/week10/Week10ApplicationTests.kt
+++ b/week10/src/test/kotlin/kotlinassignment/week10/Week10ApplicationTests.kt
@@ -2,7 +2,9 @@ package kotlinassignment.week10
 
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 
+@ActiveProfiles("local")
 @SpringBootTest
 class Week10ApplicationTests {
 


### PR DESCRIPTION
## 개요
- 20240130 과제: Controller, Service 패키지 내 클래스 개선

## 작업사항
- Controller Advice로 예외 공통화 처리하기
  - 기존에 이미 예외 공통 처리 대부분 되어 있던 상태임
  - 예외 공통 처리 더 필요한 부분 점검 후 공통화 처리
- Service 인터페이스와 구현체 분리하여 추상화 하기
  - service layer 인터페이스와 구현체 분리, JavaDoc 주석

## 변경로직
### 변경 전
- Controller Advice로 예외 공통화 처리하기 관련
  - MemberService에서 중복 이메일 예외 처리 부분에서 예외 공통화 처리 안 되어 있었음
  - service layer 메서드에서 필요 없는 주석 있었음
  - Controller Advice 역할 클래스에서 HTTP 상태 코드 잘못된 부분 있었음
  - Controller Advice 역할 클래스에서 메서드 이름 잘못된 부분 있었음
- Service 인터페이스와 구현체 분리하여 추상화 하기 관련
  - service layer 클래스들이 인터페이스와 구현 클래스를 분리, 인터페이스에 JavaDoc 주석 작성

### 변경 후
- Controller Advice로 예외 공통화 처리하기 관련
  - MemberService에서 중복 이메일 예외 처리 부분도 예외 공통화 처리
  - service layer 메서드에서 필요 없는 주석 제거
  - Controller Advice 역할 클래스에서 HTTP 상태 코드 잘못된 부분 수정
  - Controller Advice 역할 클래스에서 담당 예외와 메서드 이름이 불일치하는 부분을 이름 일치하도록 수정
- Service 인터페이스와 구현체 분리하여 추상화 하기 관련
  - service layer에서 인터페이스와 구현 클래스가 분리되도록 작성

## 기타
- Controller Advice 역할 클래스에서 메서드 순서 변경 - bad request, not found, unauthorized, forbidden 순으로
- ToDoCardService의 일부 메서드에서 ToDoCardId가 nullable이었던 것을 non nullable로 수정
- 테스트 프로파일 local로 변경하여 빌드 실패 발생하지 않게 함