### PR TITLE
PR Feature/week10/20240201 - QueryDSL 을 사용하여 검색 기능 만들기

### DIFF
--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/controller/ToDoCardController.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/controller/ToDoCardController.kt
@@ -24,10 +24,11 @@ class ToDoCardController(
 
     @GetMapping
     fun getToDoCardList(
-        @RequestParam(required = false) userName: String?,
+        @RequestParam(required = false) title: String?,
+        @RequestParam(required = false) memberNickname: String?,
         @RequestParam(required = false, name = "sort", defaultValue = "DESC") sortOrder: SortOrder,
     ): ResponseEntity<List<ToDoCardResponse>> {
-        val toDoCardResponsesList = toDoCardService.getAllToDoCards(userName, sortOrder.name)
+        val toDoCardResponsesList = toDoCardService.getToDoCardList(title, memberNickname, sortOrder.name)
 
         return ResponseEntity
             .status(HttpStatus.OK)

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/repository/CustomToDoCardRepository.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/repository/CustomToDoCardRepository.kt
@@ -4,8 +4,9 @@ import kotlinassignment.week10.domain.toDoCard.model.ToDoCard
 
 interface CustomToDoCardRepository {
 
-    fun findAllFilterByUserNameAndOrderBySortOrder(
-        userName: String?,
+    fun findAllFilteringByTitleOrUserNameWithSortOrder(
+        title: String?,
+        memberNickname: String?,
         sortOrder: String,
     ): List<ToDoCard>
 }

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/repository/CustomToDoCardRepositoryImpl.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/repository/CustomToDoCardRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package kotlinassignment.week10.domain.toDoCard.repository
 
+import com.querydsl.core.types.dsl.BooleanExpression
 import kotlinassignment.week10.domain.toDoCard.model.QToDoCard
 import kotlinassignment.week10.domain.toDoCard.model.ToDoCard
 import kotlinassignment.week10.infra.querydsl.QueryDslSupport
@@ -10,12 +11,14 @@ class CustomToDoCardRepositoryImpl : CustomToDoCardRepository, QueryDslSupport()
 
     private val toDoCard = QToDoCard.toDoCard
 
-    override fun findAllFilterByUserNameAndOrderBySortOrder(
-        userName: String?,
+    override fun findAllFilteringByTitleOrUserNameWithSortOrder(
+        title: String?,
+        memberNickname: String?,
         sortOrder: String,
     ): List<ToDoCard> {
         return queryFactory.selectFrom(toDoCard)
-            .let { if (userName != null) it.where(toDoCard.member.email.eq(userName)) else it } // TODO 컴파일 에러 방지용 임시 저장
+            .where(titleContains(title))
+            .where(memberNicknameEq(memberNickname))
             .orderBy(
                 when (sortOrder) {
                     "ASC" -> toDoCard.createdDateTime.asc()
@@ -23,5 +26,13 @@ class CustomToDoCardRepositoryImpl : CustomToDoCardRepository, QueryDslSupport()
                     else -> toDoCard.createdDateTime.desc()
                 }
             ).fetch()
+    }
+
+    private fun titleContains(title: String?): BooleanExpression? {
+        return if (title != null) toDoCard.title.contains(title) else null
+    }
+
+    private fun memberNicknameEq(memberNickname: String?): BooleanExpression? {
+        return if (memberNickname != null) toDoCard.member.nickname.eq(memberNickname) else null
     }
 }

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/repository/ToDoCardRepository.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/repository/ToDoCardRepository.kt
@@ -5,5 +5,4 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface ToDoCardRepository : JpaRepository<ToDoCard, Long>, CustomToDoCardRepository {
 
-    fun findAllByOrderByCreatedDateTimeDescIdDesc(): List<ToDoCard>
 }

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardService.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardService.kt
@@ -6,11 +6,11 @@ import kotlinassignment.week10.infra.security.MemberPrincipal
 interface ToDoCardService {
 
     /**
-     * @param userName (type: String?) ToDoCard 조회 시 userName으로 필터링할 경우 필요
+     * @param memberNickname (type: String?) ToDoCard 조회 시 userName으로 필터링할 경우 필요
      * @param sortOrder (type: String) ToDoCard 조회 시 정렬할 방향
      * @return (type: List<ToDoCardResponse>) 조회한 ToDoCard List를 반환
      */
-    fun getAllToDoCards(userName: String?, sortOrder: String): List<ToDoCardResponse>
+    fun getToDoCardList(title: String?, memberNickname: String?, sortOrder: String): List<ToDoCardResponse>
 
     /**
      * @param toDoCardId (type: Long) 조회할 ToDoCard의 id

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardServiceImpl.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardServiceImpl.kt
@@ -22,9 +22,9 @@ class ToDoCardServiceImpl(
     private val memberRepository: MemberRepository,
 ): ToDoCardService {
 
-    override fun getAllToDoCards(userName: String?, sortOrder: String): List<ToDoCardResponse> {
+    override fun getToDoCardList(title: String?, memberNickname: String?, sortOrder: String): List<ToDoCardResponse> {
         return toDoCardRepository
-            .findAllFilterByUserNameAndOrderBySortOrder(userName, sortOrder)
+            .findAllFilteringByTitleOrUserNameWithSortOrder(title, memberNickname, sortOrder)
             .map(ToDoCard::toResponse)
     }
 


### PR DESCRIPTION
## 개요
- QueryDSL 을 사용하여 검색 기능 만들기

## 작업 사항
- 기존 QueryDSL 을 사용한 검색 기능에 검색 기준 추가

## 변경 로직
### 변경 전
- 기존 ToDoCard 목록 조회 시 ToDoCard의 사용자 관련 검색 기능만 존재했음
  - 또한 기존 메서드는 임시로 만든 메서드로 member의 nickname을 검색할지 email을 검색할지 확정이 안 된 상태였음

### 변경 후
- 기존 QueryDSL 이용 ToDoCard 검색 기능에 title 검색 기준 추가
  - ToDoCard의 title의 일부가 일치할 경우 해당 ToDoCard 목록을 돌려주도록 검색 기준 추가
  - member 관련 검색 조건은 member의 nickname을 검색해서 일치 결과를 돌려주는 것으로 확정
  - 이에 따른 web layer, service layer 파라미터 등 수정

## 사용 방법
- ToDoCard 목록 조회 API 호출 시 HTTP 쿼리 파라미터로 title의 일부, 작성한 member의 nickname을 요청

## 기타
- 메서드 이름 수정
-  QueryDSL 사용 메서드의 where 절 BooleanExpression을 좀 더 깔끔하게 보이도록 수정
- **더 고민할 부분**: Path, BooleanBuilder 및 OrderSpecifier 관련 학습 더 진행
