### PR TITLE
PR feature/week10/20240202 - Pageable 을 사용하여 페이징 및 정렬 기능 만들기

### DIFF
--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/controller/CommentController.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/controller/CommentController.kt
@@ -5,6 +5,8 @@ import kotlinassignment.week10.domain.comment.dto.CommentResponse
 import kotlinassignment.week10.domain.comment.dto.CommentUpdateRequest
 import kotlinassignment.week10.domain.comment.service.CommentService
 import kotlinassignment.week10.infra.security.MemberPrincipal
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -15,6 +17,18 @@ import org.springframework.web.bind.annotation.*
 class CommentController(
     private val commentService: CommentService
 ) {
+
+    @GetMapping
+    fun getCommentList(
+        @PathVariable toDoCardId: Long,
+        @RequestParam(required = false, defaultValue = "0") page: Int,
+    ): ResponseEntity<Page<CommentResponse>> {
+        val pageable = PageRequest.of(page, COMMENT_PAGE_SIZE)
+
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(commentService.getCommentList(toDoCardId, pageable))
+    }
 
     @PostMapping
     fun createComment(
@@ -48,5 +62,9 @@ class CommentController(
         commentService.deleteComment(toDoCardId, commentId, memberPrincipal)
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
+    }
+
+    companion object {
+        private const val COMMENT_PAGE_SIZE = 50
     }
 }

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/dto/CommentResponse.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/dto/CommentResponse.kt
@@ -1,5 +1,6 @@
 package kotlinassignment.week10.domain.comment.dto
 
+import kotlinassignment.week10.domain.comment.model.Comment
 import java.time.LocalDateTime
 
 data class CommentResponse(
@@ -9,3 +10,13 @@ data class CommentResponse(
     val createdDateTime: LocalDateTime,
     val toDoCardId: Long,
 )
+
+fun Comment.toResponse(): CommentResponse {
+    return CommentResponse(
+        id = this.id!!,
+        content = this.content,
+        memberNickname = this.member.nickname,
+        createdDateTime = this.createdDateTime,
+        toDoCardId = this.toDoCard.id!!,
+    )
+}

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/dto/CommentUpdateRequest.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/dto/CommentUpdateRequest.kt
@@ -1,5 +1,12 @@
 package kotlinassignment.week10.domain.comment.dto
 
+import kotlinassignment.week10.domain.comment.model.Comment
+
 data class CommentUpdateRequest(
     val content: String,
 )
+
+fun Comment.updateFrom(request: CommentUpdateRequest): Comment {
+    this.content = request.content
+    return this
+}

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/model/Comment.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/model/Comment.kt
@@ -38,6 +38,7 @@ fun Comment.toResponse(): CommentResponse {
     )
 }
 
-fun Comment.updateFrom(request: CommentUpdateRequest) {
+fun Comment.updateFrom(request: CommentUpdateRequest): Comment {
     this.content = request.content
+    return this
 }

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/model/Comment.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/model/Comment.kt
@@ -1,8 +1,6 @@
 package kotlinassignment.week10.domain.comment.model
 
 import jakarta.persistence.*
-import kotlinassignment.week10.domain.comment.dto.CommentResponse
-import kotlinassignment.week10.domain.comment.dto.CommentUpdateRequest
 import kotlinassignment.week10.domain.member.model.Member
 import kotlinassignment.week10.domain.toDoCard.model.ToDoCard
 import java.time.LocalDateTime
@@ -26,19 +24,4 @@ class Comment(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long? = null
-}
-
-fun Comment.toResponse(): CommentResponse {
-    return CommentResponse(
-        id = this.id!!,
-        content = this.content,
-        memberNickname = this.member.nickname,
-        createdDateTime = this.createdDateTime,
-        toDoCardId = this.toDoCard.id!!,
-    )
-}
-
-fun Comment.updateFrom(request: CommentUpdateRequest): Comment {
-    this.content = request.content
-    return this
 }

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/repository/CommentRepository.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/repository/CommentRepository.kt
@@ -10,5 +10,5 @@ interface CommentRepository : JpaRepository<Comment, Long> {
 
     fun findByIdAndToDoCard_Id(commentId: Long, toDoCardId: Long): Comment?
 
-    fun findByToDoCardOrderByCreatedDateTimeDesc(toDoCard: ToDoCard, pageable: Pageable): Page<Comment>
+    fun findByToDoCard_IdOrderByIdDesc(toDoCardId: Long, pageable: Pageable): Page<Comment>
 }

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/service/CommentService.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/service/CommentService.kt
@@ -10,10 +10,9 @@ import org.springframework.data.domain.Pageable
 interface CommentService {
 
     /**
-     * TODO - 주석 정리
      * @param toDoCardId (type: Long) Comment와 연관된 ToDoCard의 id
-     * @param pageable (type: CommentCreateRequest)
-     * @return (type: Page<CommentResponse>)
+     * @param pageable (type: CommentCreateRequest) Comment 목록을 가져올 때 필요한 page number, page size, sort 등의 정보를 담은 pageable
+     * @return (type: Page<CommentResponse>) Comment 데이터 목록을 Page 형태로 담아 반환
      */
     fun getCommentList(toDoCardId: Long, pageable: Pageable): Page<CommentResponse>
 

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/service/CommentService.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/service/CommentService.kt
@@ -4,8 +4,18 @@ import kotlinassignment.week10.domain.comment.dto.CommentCreateRequest
 import kotlinassignment.week10.domain.comment.dto.CommentResponse
 import kotlinassignment.week10.domain.comment.dto.CommentUpdateRequest
 import kotlinassignment.week10.infra.security.MemberPrincipal
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 
 interface CommentService {
+
+    /**
+     * TODO - 주석 정리
+     * @param toDoCardId (type: Long) Comment와 연관된 ToDoCard의 id
+     * @param pageable (type: CommentCreateRequest)
+     * @return (type: Page<CommentResponse>)
+     */
+    fun getCommentList(toDoCardId: Long, pageable: Pageable): Page<CommentResponse>
 
     /**
      * @param toDoCardId (type: Long) Comment와 연관된 ToDoCard의 id

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/service/CommentServiceImpl.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/service/CommentServiceImpl.kt
@@ -26,7 +26,7 @@ class CommentServiceImpl(
 ) : CommentService {
 
     override fun getCommentList(toDoCardId: Long, pageable: Pageable): Page<CommentResponse> {
-        TODO()
+        return commentRepository.findByToDoCard_IdOrderByIdDesc(toDoCardId, pageable).map { it.toResponse() }
     }
 
     @Transactional

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/service/CommentServiceImpl.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/service/CommentServiceImpl.kt
@@ -52,10 +52,9 @@ class CommentServiceImpl(
         val targetComment =
             commentRepository.findByIdAndToDoCard_Id(commentId, toDoCardId) ?: throw ModelNotFoundException("Comment", commentId)
 
-        return targetComment
-            .also { if (it.member.id != memberPrincipal.id) throw UnauthorizedAccessException() }
-            .also { it.updateFrom(request) }
-            .let { commentRepository.save(it).toResponse() }
+        if (targetComment.member.id != memberPrincipal.id) throw UnauthorizedAccessException()
+
+        return targetComment.updateFrom(request).toResponse()
     }
 
     @Transactional

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/service/CommentServiceImpl.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/service/CommentServiceImpl.kt
@@ -49,21 +49,19 @@ class CommentServiceImpl(
         request: CommentUpdateRequest,
         memberPrincipal: MemberPrincipal
     ): CommentResponse {
-        val targetComment =
-            commentRepository.findByIdAndToDoCard_Id(commentId, toDoCardId) ?: throw ModelNotFoundException("Comment", commentId)
-
-        if (targetComment.member.id != memberPrincipal.id) throw UnauthorizedAccessException()
+        val targetComment = commentRepository.findByIdAndToDoCard_Id(commentId, toDoCardId)
+            ?: throw ModelNotFoundException("Comment", commentId)
+        check(targetComment.member.id != memberPrincipal.id) { throw UnauthorizedAccessException() }
 
         return targetComment.updateFrom(request).toResponse()
     }
 
     @Transactional
     override fun deleteComment(toDoCardId: Long, commentId: Long, memberPrincipal: MemberPrincipal): Unit {
-        val targetComment =
-            commentRepository.findByIdAndToDoCard_Id(commentId, toDoCardId) ?: throw ModelNotFoundException("Comment", commentId)
+        val targetComment = commentRepository.findByIdAndToDoCard_Id(commentId, toDoCardId)
+            ?: throw ModelNotFoundException("Comment", commentId)
+        check(targetComment.member.id != memberPrincipal.id) { throw UnauthorizedAccessException() }
 
-        targetComment
-            .also { if (it.member.id != memberPrincipal.id) throw UnauthorizedAccessException() }
-            .let { commentRepository.delete(it) }
+        commentRepository.delete(targetComment)
     }
 }

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/service/CommentServiceImpl.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/service/CommentServiceImpl.kt
@@ -12,6 +12,8 @@ import kotlinassignment.week10.domain.exception.UnauthorizedAccessException
 import kotlinassignment.week10.domain.member.repository.MemberRepository
 import kotlinassignment.week10.domain.toDoCard.repository.ToDoCardRepository
 import kotlinassignment.week10.infra.security.MemberPrincipal
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -22,6 +24,10 @@ class CommentServiceImpl(
     private val commentRepository: CommentRepository,
     private val memberRepository: MemberRepository,
 ) : CommentService {
+
+    override fun getCommentList(toDoCardId: Long, pageable: Pageable): Page<CommentResponse> {
+        TODO()
+    }
 
     @Transactional
     override fun createComment(toDoCardId: Long, request: CommentCreateRequest, memberPrincipal: MemberPrincipal): CommentResponse {

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/service/CommentServiceImpl.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/comment/service/CommentServiceImpl.kt
@@ -1,11 +1,7 @@
 package kotlinassignment.week10.domain.comment.service
 
-import kotlinassignment.week10.domain.comment.dto.CommentCreateRequest
-import kotlinassignment.week10.domain.comment.dto.CommentResponse
-import kotlinassignment.week10.domain.comment.dto.CommentUpdateRequest
+import kotlinassignment.week10.domain.comment.dto.*
 import kotlinassignment.week10.domain.comment.model.Comment
-import kotlinassignment.week10.domain.comment.model.toResponse
-import kotlinassignment.week10.domain.comment.model.updateFrom
 import kotlinassignment.week10.domain.comment.repository.CommentRepository
 import kotlinassignment.week10.domain.exception.ModelNotFoundException
 import kotlinassignment.week10.domain.exception.UnauthorizedAccessException

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/controller/ToDoCardController.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/controller/ToDoCardController.kt
@@ -78,18 +78,6 @@ class ToDoCardController(
             .body(toDoCardResponse)
     }
 
-    @DeleteMapping("/{toDoCardId}")
-    fun deleteToDoCard(
-        @PathVariable toDoCardId: Long,
-        @AuthenticationPrincipal memberPrincipal: MemberPrincipal,
-    ): ResponseEntity<Unit> {
-        toDoCardService.deleteToDoCard(toDoCardId, memberPrincipal)
-
-        return ResponseEntity
-            .status(HttpStatus.NO_CONTENT)
-            .build()
-    }
-
     @PatchMapping("/{toDoCardId}")
     fun completeToDoCard(
         @PathVariable toDoCardId: Long,
@@ -101,6 +89,18 @@ class ToDoCardController(
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(toDoCardResponse)
+    }
+
+    @DeleteMapping("/{toDoCardId}")
+    fun deleteToDoCard(
+        @PathVariable toDoCardId: Long,
+        @AuthenticationPrincipal memberPrincipal: MemberPrincipal,
+    ): ResponseEntity<Unit> {
+        toDoCardService.deleteToDoCard(toDoCardId, memberPrincipal)
+
+        return ResponseEntity
+            .status(HttpStatus.NO_CONTENT)
+            .build()
     }
 
     companion object {

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/controller/ToDoCardController.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/controller/ToDoCardController.kt
@@ -4,7 +4,9 @@ import jakarta.validation.Valid
 import kotlinassignment.week10.domain.toDoCard.dto.*
 import kotlinassignment.week10.domain.toDoCard.service.ToDoCardService
 import kotlinassignment.week10.infra.security.MemberPrincipal
-import kotlinassignment.week10.infra.util.SortOrder
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -26,8 +28,11 @@ class ToDoCardController(
     fun getToDoCardList(
         @RequestParam(required = false) title: String?,
         @RequestParam(required = false) memberNickname: String?,
-        @RequestParam(required = false, name = "sort", defaultValue = "DESC") sortOrder: SortOrder,
+        @RequestParam(required = false, defaultValue = "0") page: Int,
+        @RequestParam(required = false, name = "sort", defaultValue = "DESC") sortOrder: Sort.Direction,
     ): ResponseEntity<List<ToDoCardResponse>> {
+        val pageable: Pageable = PageRequest.of(page, TO_DO_CARD_PAGE_SIZE, sortOrder, TO_DO_CARD_SORT_PROPERTY)
+
         val toDoCardResponsesList = toDoCardService.getToDoCardList(title, memberNickname, sortOrder.name)
 
         return ResponseEntity
@@ -92,5 +97,10 @@ class ToDoCardController(
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(toDoCardResponse)
+    }
+
+    companion object {
+        private const val TO_DO_CARD_PAGE_SIZE = 5
+        private const val TO_DO_CARD_SORT_PROPERTY = "createdDateTime"
     }
 }

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/controller/ToDoCardController.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/controller/ToDoCardController.kt
@@ -1,7 +1,10 @@
 package kotlinassignment.week10.domain.toDoCard.controller
 
 import jakarta.validation.Valid
-import kotlinassignment.week10.domain.toDoCard.dto.*
+import kotlinassignment.week10.domain.toDoCard.dto.ToDoCardCreateRequest
+import kotlinassignment.week10.domain.toDoCard.dto.ToDoCardIsCompletePatchRequest
+import kotlinassignment.week10.domain.toDoCard.dto.ToDoCardResponse
+import kotlinassignment.week10.domain.toDoCard.dto.ToDoCardUpdateRequest
 import kotlinassignment.week10.domain.toDoCard.service.ToDoCardService
 import kotlinassignment.week10.infra.security.MemberPrincipal
 import org.springframework.data.domain.Page
@@ -42,12 +45,12 @@ class ToDoCardController(
     }
 
     @GetMapping("/{toDoCardId}")
-    fun getToDoCard(@PathVariable toDoCardId: Long): ResponseEntity<ToDoCardResponseWithComments> {
-        val toDoCardResponseWithComments = toDoCardService.getToDoCardById(toDoCardId)
+    fun getToDoCard(@PathVariable toDoCardId: Long): ResponseEntity<ToDoCardResponse> {
+        val toDoCardResponse = toDoCardService.getToDoCardById(toDoCardId)
 
         return ResponseEntity
             .status(HttpStatus.OK)
-            .body(toDoCardResponseWithComments)
+            .body(toDoCardResponse)
     }
 
     @PostMapping

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/controller/ToDoCardController.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/controller/ToDoCardController.kt
@@ -33,7 +33,7 @@ class ToDoCardController(
     ): ResponseEntity<List<ToDoCardResponse>> {
         val pageable: Pageable = PageRequest.of(page, TO_DO_CARD_PAGE_SIZE, sortOrder, TO_DO_CARD_SORT_PROPERTY)
 
-        val toDoCardResponsesList = toDoCardService.getToDoCardList(title, memberNickname, sortOrder.name)
+        val toDoCardResponsesList = toDoCardService.getToDoCardList(title, memberNickname, pageable)
 
         return ResponseEntity
             .status(HttpStatus.OK)

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/controller/ToDoCardController.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/controller/ToDoCardController.kt
@@ -4,6 +4,7 @@ import jakarta.validation.Valid
 import kotlinassignment.week10.domain.toDoCard.dto.*
 import kotlinassignment.week10.domain.toDoCard.service.ToDoCardService
 import kotlinassignment.week10.infra.security.MemberPrincipal
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
@@ -30,14 +31,14 @@ class ToDoCardController(
         @RequestParam(required = false) memberNickname: String?,
         @RequestParam(required = false, defaultValue = "0") page: Int,
         @RequestParam(required = false, name = "sort", defaultValue = "DESC") sortOrder: Sort.Direction,
-    ): ResponseEntity<List<ToDoCardResponse>> {
+    ): ResponseEntity<Page<ToDoCardResponse>> {
         val pageable: Pageable = PageRequest.of(page, TO_DO_CARD_PAGE_SIZE, sortOrder, TO_DO_CARD_SORT_PROPERTY)
 
-        val toDoCardResponsesList = toDoCardService.getToDoCardList(title, memberNickname, pageable)
+        val toDoCardResponsesPage = toDoCardService.getToDoCardList(title, memberNickname, pageable)
 
         return ResponseEntity
             .status(HttpStatus.OK)
-            .body(toDoCardResponsesList)
+            .body(toDoCardResponsesPage)
     }
 
     @GetMapping("/{toDoCardId}")

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/dto/ToDoCardResponse.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/dto/ToDoCardResponse.kt
@@ -1,12 +1,24 @@
 package kotlinassignment.week10.domain.toDoCard.dto
 
+import kotlinassignment.week10.domain.toDoCard.model.ToDoCard
 import java.time.LocalDateTime
 
 data class ToDoCardResponse(
     val id: Long,
     val title: String,
     val description: String?,
-    val memberNickname: String, // TODO nickname 등으로 수정 필요 - entity까지 수정 필요해짐
+    val memberNickname: String,
     val createdDateTime: LocalDateTime,
     val isComplete: Boolean,
 )
+
+fun ToDoCard.toResponse(): ToDoCardResponse {
+    return ToDoCardResponse(
+        id = this.id!!,
+        title = this.title,
+        description = this.description,
+        memberNickname = this.member.nickname,
+        createdDateTime = this.createdDateTime,
+        isComplete = this.isComplete,
+    )
+}

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/model/ToDoCard.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/model/ToDoCard.kt
@@ -1,13 +1,9 @@
 package kotlinassignment.week10.domain.toDoCard.model
 
 import jakarta.persistence.*
-import kotlinassignment.week10.domain.comment.dto.CommentResponse
 import kotlinassignment.week10.domain.comment.model.Comment
-import kotlinassignment.week10.domain.comment.model.toResponse
-import kotlinassignment.week10.domain.exception.StringLengthOutOfRangeException
+import kotlinassignment.week10.domain.exception.StringLengthOutOfRangeException // TODO 엔티티가 커스텀한 exception을 알고 있는 게 괜찮을지 고민해보기
 import kotlinassignment.week10.domain.member.model.Member
-import kotlinassignment.week10.domain.toDoCard.dto.ToDoCardResponse
-import kotlinassignment.week10.domain.toDoCard.dto.ToDoCardResponseWithComments
 import java.time.LocalDateTime
 
 @Entity
@@ -49,56 +45,11 @@ class ToDoCard(
             return target
         else throw StringLengthOutOfRangeException(propertyName, minLength = minLength, maxLength = maxLength)
     }
-}
 
-const val TITLE_MIN_LENGTH: Long = 1
-const val TITLE_MAX_LENGTH: Long = 200
-const val DESCRIPTION_MIN_LENGTH: Long = 1
-const val DESCRIPTION_MAX_LENGTH: Long = 1_000
-
-fun ToDoCard.toResponse(): ToDoCardResponse {
-    return ToDoCardResponse(
-        id = this.id!!,
-        title = this.title,
-        description = this.description,
-        memberNickname = this.member.nickname,
-        createdDateTime = this.createdDateTime,
-        isComplete = this.isComplete,
-    )
+    companion object {
+        const val TITLE_MIN_LENGTH: Long = 1
+        const val TITLE_MAX_LENGTH: Long = 200
+        const val DESCRIPTION_MIN_LENGTH: Long = 1
+        const val DESCRIPTION_MAX_LENGTH: Long = 1_000
+    }
 }
-
-fun ToDoCard.toResponseWithComments(): ToDoCardResponseWithComments {
-    /*
-     ?? ToDoCard의 comments를 사용하지 않고, comment repository에서 페이징 처리한 comment를 가져오며 사용하지 않게 된 메서드
-     ToDoCard가 참조하고 있는 comments를 사용하지 않고, comment repository 쪽에서 따로 Page 처리된 Comment들을 가져옴
-     ToDoCard에서 직접 comments를 꺼내올 때도 paging 처리되게 하려면 어떻게 해야하는지 알아보기
-     */
-    return ToDoCardResponseWithComments(
-        id = this.id!!,
-        title = this.title,
-        description = this.description,
-        memberNickname = this.member.nickname,
-        createdDateTime = this.createdDateTime,
-        comments = this.comments.map { it.toResponse() }.sortedByDescending { it.createdDateTime },
-        isComplete = this.isComplete,
-    )
-}
-
-fun ToDoCard.toResponseWithComments(comments: List<CommentResponse>): ToDoCardResponseWithComments {
-    return ToDoCardResponseWithComments(
-        id = this.id!!,
-        title = this.title,
-        description = this.description,
-        memberNickname = this.member.nickname,
-        createdDateTime = this.createdDateTime,
-        comments = comments,
-        isComplete = this.isComplete,
-    )
-}
-
-/*
-// CommentService에서 createComment() 할 때 더티 체킹 사용하지 않게 되면서 주석 처리
-fun ToDoCard.addComment(comment: Comment) {
-    this.comments.add(comment)
-}
- */

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/repository/CustomToDoCardRepository.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/repository/CustomToDoCardRepository.kt
@@ -1,12 +1,13 @@
 package kotlinassignment.week10.domain.toDoCard.repository
 
 import kotlinassignment.week10.domain.toDoCard.model.ToDoCard
+import org.springframework.data.domain.Pageable
 
 interface CustomToDoCardRepository {
 
     fun findAllFilteringByTitleOrUserNameWithSortOrder(
         title: String?,
         memberNickname: String?,
-        sortOrder: String,
+        pageable: Pageable,
     ): List<ToDoCard>
 }

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/repository/CustomToDoCardRepository.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/repository/CustomToDoCardRepository.kt
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Pageable
 
 interface CustomToDoCardRepository {
 
-    fun findAllFilteringByTitleOrUserNameWithSortOrder(
+    fun findAllFilteringByTitleOrUserName(
         title: String?,
         memberNickname: String?,
         pageable: Pageable,

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/repository/CustomToDoCardRepository.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/repository/CustomToDoCardRepository.kt
@@ -1,6 +1,7 @@
 package kotlinassignment.week10.domain.toDoCard.repository
 
 import kotlinassignment.week10.domain.toDoCard.model.ToDoCard
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 
 interface CustomToDoCardRepository {
@@ -9,5 +10,5 @@ interface CustomToDoCardRepository {
         title: String?,
         memberNickname: String?,
         pageable: Pageable,
-    ): List<ToDoCard>
+    ): Page<ToDoCard>
 }

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/repository/CustomToDoCardRepositoryImpl.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/repository/CustomToDoCardRepositoryImpl.kt
@@ -4,6 +4,9 @@ import com.querydsl.core.types.dsl.BooleanExpression
 import kotlinassignment.week10.domain.toDoCard.model.QToDoCard
 import kotlinassignment.week10.domain.toDoCard.model.ToDoCard
 import kotlinassignment.week10.infra.querydsl.QueryDslSupport
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort.Direction.ASC
+import org.springframework.data.domain.Sort.Direction.DESC
 
 // @Repository // 이것마저 붙이지 않아도 동작함... https://docs.spring.io/spring-data/jpa/reference/repositories/custom-implementations.html
 class CustomToDoCardRepositoryImpl : CustomToDoCardRepository, QueryDslSupport() {
@@ -14,16 +17,16 @@ class CustomToDoCardRepositoryImpl : CustomToDoCardRepository, QueryDslSupport()
     override fun findAllFilteringByTitleOrUserNameWithSortOrder(
         title: String?,
         memberNickname: String?,
-        sortOrder: String,
+        pageable: Pageable,
     ): List<ToDoCard> {
         return queryFactory.selectFrom(toDoCard)
             .where(titleContains(title))
             .where(memberNicknameEq(memberNickname))
             .orderBy(
-                when (sortOrder) {
-                    "ASC" -> toDoCard.createdDateTime.asc()
-                    "DESC" -> toDoCard.createdDateTime.desc()
-                    else -> toDoCard.createdDateTime.desc()
+                when (pageable.sort.first()?.direction) {
+                    DESC -> toDoCard.createdDateTime.desc()
+                    ASC -> toDoCard.createdDateTime.asc()
+                    null -> toDoCard.createdDateTime.desc()
                 }
             ).fetch()
     }

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/repository/CustomToDoCardRepositoryImpl.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/repository/CustomToDoCardRepositoryImpl.kt
@@ -17,7 +17,7 @@ class CustomToDoCardRepositoryImpl : CustomToDoCardRepository, QueryDslSupport()
 
     private val toDoCard = QToDoCard.toDoCard
 
-    override fun findAllFilteringByTitleOrUserNameWithSortOrder(
+    override fun findAllFilteringByTitleOrUserName(
         title: String?,
         memberNickname: String?,
         pageable: Pageable,
@@ -31,9 +31,9 @@ class CustomToDoCardRepositoryImpl : CustomToDoCardRepository, QueryDslSupport()
             .where(whereClause)
             .orderBy(
                 when (pageable.sort.first()?.direction) {
-                    DESC -> toDoCard.createdDateTime.desc()
-                    ASC -> toDoCard.createdDateTime.asc()
-                    null -> toDoCard.createdDateTime.desc()
+                    DESC -> toDoCard.id.desc()
+                    ASC -> toDoCard.id.asc()
+                    null -> toDoCard.id.desc()
                 }
             ).fetch()
 

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardService.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardService.kt
@@ -2,6 +2,7 @@ package kotlinassignment.week10.domain.toDoCard.service
 
 import kotlinassignment.week10.domain.toDoCard.dto.*
 import kotlinassignment.week10.infra.security.MemberPrincipal
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 
 interface ToDoCardService {
@@ -11,7 +12,7 @@ interface ToDoCardService {
      * @param sortOrder (type: String) ToDoCard 조회 시 정렬할 방향
      * @return (type: List<ToDoCardResponse>) 조회한 ToDoCard List를 반환
      */
-    fun getToDoCardList(title: String?, memberNickname: String?, pageable: Pageable): List<ToDoCardResponse>
+    fun getToDoCardList(title: String?, memberNickname: String?, pageable: Pageable): Page<ToDoCardResponse>
 
     /**
      * @param toDoCardId (type: Long) 조회할 ToDoCard의 id

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardService.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardService.kt
@@ -2,6 +2,7 @@ package kotlinassignment.week10.domain.toDoCard.service
 
 import kotlinassignment.week10.domain.toDoCard.dto.*
 import kotlinassignment.week10.infra.security.MemberPrincipal
+import org.springframework.data.domain.Pageable
 
 interface ToDoCardService {
 
@@ -10,7 +11,7 @@ interface ToDoCardService {
      * @param sortOrder (type: String) ToDoCard 조회 시 정렬할 방향
      * @return (type: List<ToDoCardResponse>) 조회한 ToDoCard List를 반환
      */
-    fun getToDoCardList(title: String?, memberNickname: String?, sortOrder: String): List<ToDoCardResponse>
+    fun getToDoCardList(title: String?, memberNickname: String?, pageable: Pageable): List<ToDoCardResponse>
 
     /**
      * @param toDoCardId (type: Long) 조회할 ToDoCard의 id

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardService.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardService.kt
@@ -8,11 +8,10 @@ import org.springframework.data.domain.Pageable
 interface ToDoCardService {
 
     /**
-     * TODO - 주석 정리
-     * @param title (type: String?)
+     * @param title (type: String?) ToDoCard 조회 시 title로 필터링할 경우 필요
      * @param memberNickname (type: String?) ToDoCard 조회 시 member의 nickname으로 필터링할 경우 필요
-     * @param pageable (type: Pageable)
-     * @return (type: Page<ToDoCardResponse>) 조회한 ToDoCard의 Page를 ToDoCardResponse의 Page로 변환하여 반환
+     * @param pageable (type: Pageable) ToDoCard 목록을 가져올 때 필요한 page number, page size, sort 등의 정보를 담은 pageable
+     * @return (type: Page<ToDoCardResponse>) ToDoCard 데이터 목록을 Page 형태로 담아 반환
      */
     fun getToDoCardList(title: String?, memberNickname: String?, pageable: Pageable): Page<ToDoCardResponse>
 

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardService.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardService.kt
@@ -8,17 +8,19 @@ import org.springframework.data.domain.Pageable
 interface ToDoCardService {
 
     /**
-     * @param memberNickname (type: String?) ToDoCard 조회 시 userName으로 필터링할 경우 필요
-     * @param sortOrder (type: String) ToDoCard 조회 시 정렬할 방향
-     * @return (type: List<ToDoCardResponse>) 조회한 ToDoCard List를 반환
+     * TODO - 주석 정리
+     * @param title (type: String?)
+     * @param memberNickname (type: String?) ToDoCard 조회 시 member의 nickname으로 필터링할 경우 필요
+     * @param pageable (type: Pageable)
+     * @return (type: Page<ToDoCardResponse>) 조회한 ToDoCard의 Page를 ToDoCardResponse의 Page로 변환하여 반환
      */
     fun getToDoCardList(title: String?, memberNickname: String?, pageable: Pageable): Page<ToDoCardResponse>
 
     /**
      * @param toDoCardId (type: Long) 조회할 ToDoCard의 id
-     * @return (type: ToDoCardResponseWithComments) parameter로 받은 ToDoCard id와 일치하는 id를 가진 ToDoCard 조회 결과 반환
+     * @return (type: ToDoCardResponse) parameter로 받은 ToDoCard id와 일치하는 id를 가진 ToDoCard 조회 결과 반환
      */
-    fun getToDoCardById(toDoCardId: Long): ToDoCardResponseWithComments
+    fun getToDoCardById(toDoCardId: Long): ToDoCardResponse
 
     /**
      * @param request (type: ToDoCardCreateRequest) ToDoCard 생성을 위한 DTO

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardServiceImpl.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardServiceImpl.kt
@@ -10,6 +10,7 @@ import kotlinassignment.week10.domain.toDoCard.model.*
 import kotlinassignment.week10.domain.toDoCard.repository.ToDoCardRepository
 import kotlinassignment.week10.infra.aop.EvaluateExecutionTime
 import kotlinassignment.week10.infra.security.MemberPrincipal
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
@@ -23,7 +24,7 @@ class ToDoCardServiceImpl(
     private val memberRepository: MemberRepository,
 ): ToDoCardService {
 
-    override fun getToDoCardList(title: String?, memberNickname: String?, pageable: Pageable): List<ToDoCardResponse> {
+    override fun getToDoCardList(title: String?, memberNickname: String?, pageable: Pageable): Page<ToDoCardResponse> {
         return toDoCardRepository
             .findAllFilteringByTitleOrUserNameWithSortOrder(title, memberNickname, pageable)
             .map(ToDoCard::toResponse)

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardServiceImpl.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardServiceImpl.kt
@@ -11,6 +11,7 @@ import kotlinassignment.week10.domain.toDoCard.repository.ToDoCardRepository
 import kotlinassignment.week10.infra.aop.EvaluateExecutionTime
 import kotlinassignment.week10.infra.security.MemberPrincipal
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -22,9 +23,9 @@ class ToDoCardServiceImpl(
     private val memberRepository: MemberRepository,
 ): ToDoCardService {
 
-    override fun getToDoCardList(title: String?, memberNickname: String?, sortOrder: String): List<ToDoCardResponse> {
+    override fun getToDoCardList(title: String?, memberNickname: String?, pageable: Pageable): List<ToDoCardResponse> {
         return toDoCardRepository
-            .findAllFilteringByTitleOrUserNameWithSortOrder(title, memberNickname, sortOrder)
+            .findAllFilteringByTitleOrUserNameWithSortOrder(title, memberNickname, pageable)
             .map(ToDoCard::toResponse)
     }
 

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardServiceImpl.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardServiceImpl.kt
@@ -72,17 +72,7 @@ class ToDoCardServiceImpl(
         toDoCard.title = title
         toDoCard.description = description
 
-        return toDoCardRepository.save(toDoCard).toResponse()
-    }
-
-    @Transactional
-    override fun deleteToDoCard(toDoCardId: Long, memberPrincipal: MemberPrincipal): Unit {
-        // 이 부분이 있어도 select query는 한 번만 나간다. 없는 id로 delete 시도하는 경우 확실한 에러 메시지를 주기 위함
-        val toDoCard = toDoCardRepository.findByIdOrNull(toDoCardId)
-            ?.also { if (it.member.id != memberPrincipal.id) throw UnauthorizedAccessException() }
-            ?: throw ModelNotFoundException("ToDoCard", toDoCardId)
-
-        return toDoCardRepository.delete(toDoCard)
+        return toDoCard.toResponse()
     }
 
     @Transactional
@@ -93,5 +83,15 @@ class ToDoCardServiceImpl(
         toDoCard.isComplete = request.isComplete
 
         return toDoCard.toResponse()
+    }
+
+    @Transactional
+    override fun deleteToDoCard(toDoCardId: Long, memberPrincipal: MemberPrincipal): Unit {
+        // 이 부분이 있어도 select query는 한 번만 나간다. 없는 id로 delete 시도하는 경우 확실한 에러 메시지를 주기 위함
+        val toDoCard = toDoCardRepository.findByIdOrNull(toDoCardId)
+            ?.also { if (it.member.id != memberPrincipal.id) throw UnauthorizedAccessException() }
+            ?: throw ModelNotFoundException("ToDoCard", toDoCardId)
+
+        return toDoCardRepository.delete(toDoCard)
     }
 }

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardServiceImpl.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardServiceImpl.kt
@@ -3,12 +3,8 @@ package kotlinassignment.week10.domain.toDoCard.service
 import kotlinassignment.week10.domain.exception.ModelNotFoundException
 import kotlinassignment.week10.domain.exception.UnauthorizedAccessException
 import kotlinassignment.week10.domain.member.repository.MemberRepository
-import kotlinassignment.week10.domain.toDoCard.dto.ToDoCardCreateRequest
-import kotlinassignment.week10.domain.toDoCard.dto.ToDoCardIsCompletePatchRequest
-import kotlinassignment.week10.domain.toDoCard.dto.ToDoCardResponse
-import kotlinassignment.week10.domain.toDoCard.dto.ToDoCardUpdateRequest
+import kotlinassignment.week10.domain.toDoCard.dto.*
 import kotlinassignment.week10.domain.toDoCard.model.ToDoCard
-import kotlinassignment.week10.domain.toDoCard.model.toResponse
 import kotlinassignment.week10.domain.toDoCard.repository.ToDoCardRepository
 import kotlinassignment.week10.infra.aop.EvaluateExecutionTime
 import kotlinassignment.week10.infra.security.MemberPrincipal
@@ -60,6 +56,7 @@ class ToDoCardServiceImpl(
             member = member,
             createdDateTime = request.createdDateTime,
         ).let { toDoCardRepository.save(it).toResponse() }
+
     }
 
     @Transactional

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardServiceImpl.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardServiceImpl.kt
@@ -31,18 +31,19 @@ class ToDoCardServiceImpl(
     }
 
     @EvaluateExecutionTime
-    override fun getToDoCardById(toDoCardId: Long): ToDoCardResponseWithComments {
+    override fun getToDoCardById(toDoCardId: Long): ToDoCardResponse {
         val toDoCard = toDoCardRepository.findByIdOrNull(toDoCardId) ?: throw ModelNotFoundException("ToDoCard", toDoCardId)
 
         /*
          TODO ToDoCard가 참조하고 있는 comments를 사용하지 않고, comment repository 쪽에서 따로 Page 처리된 Comment들을 가져옴
-          ToDoCard에서 직접 comments를 꺼내올 때도 paging 처리되게 하려면 어떻게 해야하는지 알아보기
+          - ToDoCard에서 직접 comments를 꺼내올 때도 paging 처리되게 하려면 어떻게 해야하는지 알아보기
+          - comment 가져오는 API 및 흐름 분리하였음
+          // val pageRequest = PageRequest.of(0, 50) // 이 부분은 임시로 값을 넣어놨음, 추후 제대로 처리할 것
+          // val commentPage =
+          // commentRepository.findByToDoCardOrderByCreatedDateTimeDesc(toDoCard, pageRequest)
          */
-        val pageRequest = PageRequest.of(0, 100) // TODO 이 부분은 임시로 값을 넣어놨음, 추후 제대로 처리할 것
-        val commentPage =
-            commentRepository.findByToDoCardOrderByCreatedDateTimeDesc(toDoCard, pageRequest)
 
-        return toDoCard.toResponseWithComments(commentPage.map { it.toResponse() }.toList())
+        return toDoCard.toResponse()
     }
 
     @Transactional

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardServiceImpl.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardServiceImpl.kt
@@ -1,17 +1,18 @@
 package kotlinassignment.week10.domain.toDoCard.service
 
-import kotlinassignment.week10.domain.comment.model.toResponse
-import kotlinassignment.week10.domain.comment.repository.CommentRepository
 import kotlinassignment.week10.domain.exception.ModelNotFoundException
 import kotlinassignment.week10.domain.exception.UnauthorizedAccessException
 import kotlinassignment.week10.domain.member.repository.MemberRepository
-import kotlinassignment.week10.domain.toDoCard.dto.*
-import kotlinassignment.week10.domain.toDoCard.model.*
+import kotlinassignment.week10.domain.toDoCard.dto.ToDoCardCreateRequest
+import kotlinassignment.week10.domain.toDoCard.dto.ToDoCardIsCompletePatchRequest
+import kotlinassignment.week10.domain.toDoCard.dto.ToDoCardResponse
+import kotlinassignment.week10.domain.toDoCard.dto.ToDoCardUpdateRequest
+import kotlinassignment.week10.domain.toDoCard.model.ToDoCard
+import kotlinassignment.week10.domain.toDoCard.model.toResponse
 import kotlinassignment.week10.domain.toDoCard.repository.ToDoCardRepository
 import kotlinassignment.week10.infra.aop.EvaluateExecutionTime
 import kotlinassignment.week10.infra.security.MemberPrincipal
 import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -20,13 +21,12 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class ToDoCardServiceImpl(
     private val toDoCardRepository: ToDoCardRepository,
-    private val commentRepository: CommentRepository,
     private val memberRepository: MemberRepository,
 ): ToDoCardService {
 
     override fun getToDoCardList(title: String?, memberNickname: String?, pageable: Pageable): Page<ToDoCardResponse> {
         return toDoCardRepository
-            .findAllFilteringByTitleOrUserNameWithSortOrder(title, memberNickname, pageable)
+            .findAllFilteringByTitleOrUserName(title, memberNickname, pageable)
             .map(ToDoCard::toResponse)
     }
 

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardServiceImpl.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardServiceImpl.kt
@@ -64,9 +64,8 @@ class ToDoCardServiceImpl(
 
     @Transactional
     override fun updateToDoCard(toDoCardId: Long, request: ToDoCardUpdateRequest, memberPrincipal: MemberPrincipal): ToDoCardResponse {
-        val toDoCard = toDoCardRepository.findByIdOrNull(toDoCardId)
-            ?.also { if (it.member.id != memberPrincipal.id) throw UnauthorizedAccessException() }
-            ?: throw ModelNotFoundException("ToDoCard", toDoCardId)
+        val toDoCard = toDoCardRepository.findByIdOrNull(toDoCardId) ?: throw ModelNotFoundException("ToDoCard", toDoCardId)
+        check(toDoCard.member.id != memberPrincipal.id) { throw UnauthorizedAccessException() }
 
         val (title: String?, description: String?) = request
         toDoCard.title = title
@@ -77,9 +76,9 @@ class ToDoCardServiceImpl(
 
     @Transactional
     override fun completeToDoCard(toDoCardId: Long, request: ToDoCardIsCompletePatchRequest, memberPrincipal: MemberPrincipal): ToDoCardResponse {
-        val toDoCard = toDoCardRepository.findByIdOrNull(toDoCardId)
-            ?.also { if (it.member.id != memberPrincipal.id) throw UnauthorizedAccessException() }
-            ?: throw ModelNotFoundException("ToDoCard", toDoCardId)
+        val toDoCard = toDoCardRepository.findByIdOrNull(toDoCardId) ?: throw ModelNotFoundException("ToDoCard", toDoCardId)
+        check(toDoCard.member.id != memberPrincipal.id) { throw UnauthorizedAccessException() }
+
         toDoCard.isComplete = request.isComplete
 
         return toDoCard.toResponse()
@@ -88,9 +87,8 @@ class ToDoCardServiceImpl(
     @Transactional
     override fun deleteToDoCard(toDoCardId: Long, memberPrincipal: MemberPrincipal): Unit {
         // 이 부분이 있어도 select query는 한 번만 나간다. 없는 id로 delete 시도하는 경우 확실한 에러 메시지를 주기 위함
-        val toDoCard = toDoCardRepository.findByIdOrNull(toDoCardId)
-            ?.also { if (it.member.id != memberPrincipal.id) throw UnauthorizedAccessException() }
-            ?: throw ModelNotFoundException("ToDoCard", toDoCardId)
+        val toDoCard = toDoCardRepository.findByIdOrNull(toDoCardId) ?: throw ModelNotFoundException("ToDoCard", toDoCardId)
+        check(toDoCard.member.id != memberPrincipal.id) { throw UnauthorizedAccessException() }
 
         return toDoCardRepository.delete(toDoCard)
     }

--- a/week10/src/main/kotlin/kotlinassignment/week10/infra/util/SortOrder.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/infra/util/SortOrder.kt
@@ -1,5 +1,0 @@
-package kotlinassignment.week10.infra.util
-
-enum class SortOrder {
-    ASC, DESC
-}


### PR DESCRIPTION
## 개요
- Pageable 을 사용하여 페이징 및 정렬 기능 만들기

## 작업 사항
- Pageable 을 사용하여 페이징 및 정렬 기능 만들기
- 기타 service layer 및 domain 수정

## 변경 로직
### 변경 전
- ToDoCard 목록 조회 시 페이징 처리 없었음
- Comment 목록 조회 API 없었음
  - ToDoCard 단건 조회 시 페이징 처리된 Comment 목록을 가져오도록 처리한 형태였음

### 변경 후
- ToDoCard 목록 조회 시 페이징 처리(QueryDSL과 함께 사용됨)
- Comment 목록 조회 API 추가
  - 목록 조회 시 페이징 처리(일반적인 Spring Data JPA로 Pageable 처리)

## 사용 방법
- ToDoCard, Comment 목록 조회 API 호출 시 원하는 page를 쿼리 파라미터로 함께 넘김
  - ToDoCard의 경우 sort 파라미터를 넘겨서 Id 순서로 오름차순, 내림차순 순서 변경 가능

## 기타
- 기존 createdDateTime 순으로 정렬했으나, Id 순으로 정렬하도록 변경함
- 심화 개인 과제 피드백 반영: entity 수정 시 더티 체킹 사용하는 쪽으로 일관성 있게 수정
- 자원 소유자 권한 확인 시 if가 아닌 Preconditions의 check 함수 사용
- Entity에서 DTO를 모르도록 확장함수 위치 변경
- **더 고민할 부분**
  - **QueryDSL과 Pageable 함께 사용한 ToDoCard 목록 조회 메서드에서 복잡한 쿼리가 나가고 있는 듯함**
    - 쿼리 다시 확인하고 고민할 것