### PR TITLE
PR feature/week10/20240205 - 다양한 조건을 동적 쿼리로 처리하기

### DIFF
--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/controller/ToDoCardController.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/controller/ToDoCardController.kt
@@ -31,17 +31,29 @@ class ToDoCardController(
     @GetMapping
     fun getToDoCardList(
         @RequestParam(required = false) title: String?,
+        @RequestParam(required = false) category: String?,
+        @RequestParam(required = false) tag: String?,
+        @RequestParam(required = false) state: String?,
+        @RequestParam(required = false) dayDuration: String?,
         @RequestParam(required = false) memberNickname: String?,
         @RequestParam(required = false, defaultValue = "0") page: Int,
         @RequestParam(required = false, name = "sort", defaultValue = "DESC") sortOrder: Sort.Direction,
     ): ResponseEntity<Page<ToDoCardResponse>> {
         val pageable: Pageable = PageRequest.of(page, TO_DO_CARD_PAGE_SIZE, sortOrder, TO_DO_CARD_SORT_PROPERTY)
 
-        val toDoCardResponsesPage = toDoCardService.getToDoCardList(title, memberNickname, pageable)
+        val toDoCardResponsePage = toDoCardService.getToDoCardList(
+            title = title,
+            category = category,
+            tag = tag,
+            state = state,
+            dayDuration = dayDuration,
+            memberNickname = memberNickname,
+            pageable = pageable,
+        )
 
         return ResponseEntity
             .status(HttpStatus.OK)
-            .body(toDoCardResponsesPage)
+            .body(toDoCardResponsePage)
     }
 
     @GetMapping("/{toDoCardId}")

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/model/ToDoCard.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/model/ToDoCard.kt
@@ -33,8 +33,14 @@ class ToDoCard(
             field = getStringAfterLengthValidation(value, "description", minLength = DESCRIPTION_MIN_LENGTH, maxLength = DESCRIPTION_MAX_LENGTH)
         }
 
-    @Column(columnDefinition = "boolean default false") // https://m.blog.naver.com/younjh5369/222763814571 // https://www.baeldung.com/jpa-default-column-values
-    var isComplete: Boolean = false
+    // https://m.blog.naver.com/younjh5369/222763814571 // https://www.baeldung.com/jpa-default-column-values
+    @Column(columnDefinition = "boolean default false") var isComplete: Boolean = false
+
+    @Column var category: String? = null
+
+    @Column var tag: String? = null
+
+    @Column var state: String? = null // TODO category, tag, state 관련 조금 더 정제할 것
 
     private fun getStringAfterLengthValidation(target: String, propertyName: String, minLength: Long, maxLength: Long): String {
         if (target.length in minLength..maxLength)

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/repository/CustomToDoCardRepository.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/repository/CustomToDoCardRepository.kt
@@ -8,6 +8,10 @@ interface CustomToDoCardRepository {
 
     fun findAllFilteringByTitleOrUserName(
         title: String?,
+        category: String?,
+        tag: String?,
+        state: String?,
+        dayDuration: String?,
         memberNickname: String?,
         pageable: Pageable,
     ): Page<ToDoCard>

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/repository/CustomToDoCardRepositoryImpl.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/repository/CustomToDoCardRepositoryImpl.kt
@@ -19,8 +19,12 @@ class CustomToDoCardRepositoryImpl : CustomToDoCardRepository, QueryDslSupport()
 
     override fun findAllFilteringByTitleOrUserName(
         title: String?,
+        category: String?,
+        tag: String?,
+        state: String?,
+        dayDuration: String?,
         memberNickname: String?,
-        pageable: Pageable,
+        pageable: Pageable
     ): Page<ToDoCard> {
 
         val whereClause = BooleanBuilder()

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardService.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardService.kt
@@ -9,11 +9,23 @@ interface ToDoCardService {
 
     /**
      * @param title (type: String?) ToDoCard 조회 시 title로 필터링할 경우 필요
+     * @param category (type: String?) ToDoCard 조회 시 category로 필터링할 경우 필요
+     * @param tag (type: String?) ToDoCard 조회 시 tag로 필터링할 경우 필요
+     * @param state (type: String?) ToDoCard 조회 시 state 필터링할 경우 필요
+     * @param dayDuration (type: String?) ToDoCard 조회 시 dayDuration로 필터링할 경우 필요
      * @param memberNickname (type: String?) ToDoCard 조회 시 member의 nickname으로 필터링할 경우 필요
      * @param pageable (type: Pageable) ToDoCard 목록을 가져올 때 필요한 page number, page size, sort 등의 정보를 담은 pageable
      * @return (type: Page<ToDoCardResponse>) ToDoCard 데이터 목록을 Page 형태로 담아 반환
      */
-    fun getToDoCardList(title: String?, memberNickname: String?, pageable: Pageable): Page<ToDoCardResponse>
+    fun getToDoCardList(
+        title: String?,
+        category: String?,
+        tag: String?,
+        state: String?,
+        dayDuration: String?,
+        memberNickname: String?,
+        pageable: Pageable
+    ): Page<ToDoCardResponse>
 
     /**
      * @param toDoCardId (type: Long) 조회할 ToDoCard의 id

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardServiceImpl.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardServiceImpl.kt
@@ -21,6 +21,7 @@ class ToDoCardServiceImpl(
     private val memberRepository: MemberRepository,
 ): ToDoCardService {
 
+    @EvaluateExecutionTime
     override fun getToDoCardList(
         title: String?,
         category: String?,

--- a/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardServiceImpl.kt
+++ b/week10/src/main/kotlin/kotlinassignment/week10/domain/toDoCard/service/ToDoCardServiceImpl.kt
@@ -21,10 +21,27 @@ class ToDoCardServiceImpl(
     private val memberRepository: MemberRepository,
 ): ToDoCardService {
 
-    override fun getToDoCardList(title: String?, memberNickname: String?, pageable: Pageable): Page<ToDoCardResponse> {
-        return toDoCardRepository
-            .findAllFilteringByTitleOrUserName(title, memberNickname, pageable)
-            .map(ToDoCard::toResponse)
+    override fun getToDoCardList(
+        title: String?,
+        category: String?,
+        tag: String?,
+        state: String?,
+        dayDuration: String?,
+        memberNickname: String?,
+        pageable: Pageable
+    ): Page<ToDoCardResponse> {
+
+        val toDoCardPage = toDoCardRepository.findAllFilteringByTitleOrUserName(
+            title = title,
+            category = category,
+            tag = tag,
+            state = state,
+            dayDuration = dayDuration,
+            memberNickname = memberNickname,
+            pageable = pageable,
+        )
+
+        return toDoCardPage.map(ToDoCard::toResponse)
     }
 
     @EvaluateExecutionTime

--- a/week10/src/main/resources/data.sql
+++ b/week10/src/main/resources/data.sql
@@ -1,15 +1,15 @@
-insert into to_do_card(created_at, last_modified_at, deleted_at, title, description, member_id)
-values (CURRENT_TIMESTAMP - 25, CURRENT_TIMESTAMP - 25, null, '제목1', '할 일 상세1', 1),
-       (CURRENT_TIMESTAMP - 20, CURRENT_TIMESTAMP - 20, null, '두번째 글 제목', '상세한 할 일 2', 1),
-       (CURRENT_TIMESTAMP - 15, CURRENT_TIMESTAMP - 15, null, '3제목', '일3 상세 내용', 2),
-       (CURRENT_TIMESTAMP - 10, CURRENT_TIMESTAMP - 10, null, '4제목', '4내용', 1),
-       (CURRENT_TIMESTAMP - 5, CURRENT_TIMESTAMP - 5, null, '제목5', '내용5', 2);
+insert into to_do_card(created_at, last_modified_at, deleted_at, member_id, title, description)
+values (CURRENT_TIMESTAMP - 25, CURRENT_TIMESTAMP - 25, null, 1, '제목1', '할 일 상세1'),
+       (CURRENT_TIMESTAMP - 20, CURRENT_TIMESTAMP - 20, null, 1, '두번째 글 제목', '상세한 할 일 2'),
+       (CURRENT_TIMESTAMP - 15, CURRENT_TIMESTAMP - 15, null, 2, '3제목', '일3 상세 내용'),
+       (CURRENT_TIMESTAMP - 10, CURRENT_TIMESTAMP - 10, null, 1, '4제목', '4내용'),
+       (CURRENT_TIMESTAMP - 5, CURRENT_TIMESTAMP - 5, null, 2, '제목5', '내용5');
 
-insert into comment(created_at, last_modified_at, deleted_at, content, member_id, to_do_card_id)
-values (CURRENT_TIMESTAMP - 20, CURRENT_TIMESTAMP - 20, null, '댓글이야', 1, 1),
-       (CURRENT_TIMESTAMP - 15, CURRENT_TIMESTAMP - 15, null, '2댓글', 2, 1),
-       (CURRENT_TIMESTAMP - 10, CURRENT_TIMESTAMP - 10, null, '댓글 내용입니다', 1, 2),
-       (CURRENT_TIMESTAMP - 5, CURRENT_TIMESTAMP - 5, null, '아무 댓글', 2, 2);
+insert into comment(created_at, last_modified_at, deleted_at, member_id, to_do_card_id, content)
+values (CURRENT_TIMESTAMP - 20, CURRENT_TIMESTAMP - 20, null, 1, 1, '댓글이야'),
+       (CURRENT_TIMESTAMP - 15, CURRENT_TIMESTAMP - 15, null, 2, 1, '2댓글'),
+       (CURRENT_TIMESTAMP - 10, CURRENT_TIMESTAMP - 10, null, 1, 2, '댓글 내용입니다'),
+       (CURRENT_TIMESTAMP - 5, CURRENT_TIMESTAMP - 5, null, 2, 2, '아무 댓글');
 
 -- member 로컬 테스트 데이터
 -- 1. email: test, password: test

--- a/week10/src/main/resources/schema.sql
+++ b/week10/src/main/resources/schema.sql
@@ -8,10 +8,13 @@ create table to_do_card
     created_at        timestamp(6) not null,
     last_modified_at  timestamp(6) not null,
     deleted_at        timestamp(6),
+    member_id         bigint not null,
     title             varchar(255) not null,
     description       varchar(255),
-    member_id         bigint not null,
     is_complete       boolean default false,
+    category          varchar(31) default null,
+    tag               varchar(31) default null,
+    state             varchar(31) default null,
     primary key (id)
 );
 create table comment
@@ -21,7 +24,7 @@ create table comment
     last_modified_at  timestamp(6) not null,
     deleted_at        timestamp(6),
     content           varchar(255),
-    member_id           bigint not null,
+    member_id         bigint not null,
     to_do_card_id     bigint not null,
     primary key (id)
 );


### PR DESCRIPTION
## 개요
- 다양한 조건을 동적 쿼리로 처리하기

## 작업 사항
- ToDoCard 목록 조회 시 다양한 조건을 동적 쿼리로 처리

## 변경 로직
### 변경 전
- 기존에 있던 필터 조건: 제목 포함, member nickname 일치, 삭제 상태 아님

### 변경 후
- 카테고리 일치 조건, 태그 포함 조건, 상태 일치 조건, n일 전까지의 게시글만 조회 조건 추가
  - 구현 위해 ToDoCard에 category, tag, state 프로퍼티 추가, 스키마 변경

## 사용 방법
- ToDoCard 목록 조회 API(GET /todocards) 호출 시 쿼리 파라미터로 각 조건을 함께 넘김
  - (ex.) GET /todocards?title=제목&dayDuration=7

## 기타
- 현재 service layer 메서드 중 가장 성능 문제 발생 가능성 높은 메서드라 생각되어 getToDoCardList에 실행 시간 측정 AOP 적용함
- TODO: member nickname 일치 조건 및 ToDoCard 가져온 후 member nickname 조회 위해 발생하는 N + 1 문제 고민할 것
